### PR TITLE
DEV

### DIFF
--- a/docs/contracts/notica-sync-log-contract.md
+++ b/docs/contracts/notica-sync-log-contract.md
@@ -1,6 +1,6 @@
 # Notica Sync Log Contract (Lambda -> notica-app)
 
-Version: `2026-05-23.sync-log.v1`
+Version: `2026-05-31.sync-log.v2`
 
 This document defines the payload persisted as `lastSyncLog` in the Users table and emitted by `process_and_log_sync_result`.
 
@@ -39,8 +39,6 @@ Required keys for each error item:
 - `error_code: string`
 - `error_message: string | null`
 - `error: string | null`
-- `gcal_event_title: string | null`
-- `notion_task_name: string | null`
 - `gcal_event_start: string | null`
 - `gcal_event_id: string | null`
 - `notion_task_id: string | null`

--- a/src/gcal/gcal_service.py
+++ b/src/gcal/gcal_service.py
@@ -37,9 +37,7 @@ class GoogleService:
             self.logger.debug("Google Calendar connection test passed.")
             return True
         except HttpError as e:
-            self.logger.error(
-                f"Google API error: {e}. Please click 'view settings' and re-authorize"
-            )
+            self.logger.error(f"Google API error: {e}. Please click 'view settings' and re-authorize")
             return False
         except Exception as e:
             self.logger.error(f"Google Calendar Connection test failed: {e}")
@@ -68,9 +66,7 @@ class GoogleService:
 
                     if page_token:
                         if page_token in seen_page_tokens:
-                            raise RuntimeError(
-                                f"Repeated Google Calendar page token detected for calendar ID {cal_id}"
-                            )
+                            raise RuntimeError(f"Repeated Google Calendar page token detected for calendar ID {cal_id}")
                         seen_page_tokens.add(page_token)
 
                     params = {
@@ -131,9 +127,7 @@ class GoogleService:
             self.logger.exception("Error retrieving Google Calendar events")
             raise
 
-    def update_gcal_event(
-        self, notion_task, existing_gcal_cal_id, existing_gcal_event_id
-    ):
+    def update_gcal_event(self, notion_task, existing_gcal_cal_id, existing_gcal_event_id):
         event = self.make_event_body(notion_task)
         self.service.events().patch(
             calendarId=existing_gcal_cal_id, eventId=existing_gcal_event_id, body=event
@@ -143,11 +137,7 @@ class GoogleService:
         if new_gcal_calendar_id is None:
             new_gcal_calendar_id = self.notion_setting["gcal_default_id"]
         event = self.make_event_body(notion_task)
-        gcal_event = (
-            self.service.events()
-            .insert(calendarId=new_gcal_calendar_id, body=event)
-            .execute()
-        )
+        gcal_event = self.service.events().insert(calendarId=new_gcal_calendar_id, body=event).execute()
         # get the event id and update the notion task by query page id
         event_id = gcal_event.get("id")
         return event_id
@@ -164,20 +154,14 @@ class GoogleService:
             eventId=existing_gcal_event_id,
             destination=new_gcal_calendar_id,
         ).execute()
-        self.update_gcal_event(
-            notion_task, new_gcal_calendar_id, existing_gcal_event_id
-        )
+        self.update_gcal_event(notion_task, new_gcal_calendar_id, existing_gcal_event_id)
 
     def delete_gcal_event(self, gcal_calendar_id, gcal_event_id):
         try:
-            self.service.events().delete(
-                calendarId=gcal_calendar_id, eventId=gcal_event_id
-            ).execute()
+            self.service.events().delete(calendarId=gcal_calendar_id, eventId=gcal_event_id).execute()
             self.logger.info(f"Successfully deleted event with ID: {gcal_event_id}")
         except Exception as e:
-            self.logger.error(
-                f"An error occurred while deleting event with ID: {gcal_event_id}: {e}"
-            )
+            self.logger.error(f"An error occurred while deleting event with ID: {gcal_event_id}: {e}")
 
     def make_event_body(self, notion_task):
         # set icone and task name
@@ -218,9 +202,7 @@ class GoogleService:
             .get("end", "")
         )
         # Adjust and convert dates to UTC
-        event_start_date, event_end_date = self.adjust_notion_dates(
-            notion_task_start_date, notion_task_end_date
-        )
+        event_start_date, event_end_date = self.adjust_notion_dates(notion_task_start_date, notion_task_end_date)
 
         # set location
         try:
@@ -295,12 +277,8 @@ class GoogleService:
             end_date = start_date
 
         if "T" in start_date_str and end_date == start_date:  # datetime format
-            end_date = start_date + timedelta(
-                minutes=int(self.notion_setting["default_event_length"])
-            )
-        elif (
-            "T" not in start_date_str
-        ):  # date format: Google Calendar end date is exclusive, always add 1 day
+            end_date = start_date + timedelta(minutes=int(self.notion_setting["default_event_length"]))
+        elif "T" not in start_date_str:  # date format: Google Calendar end date is exclusive, always add 1 day
             end_date = end_date + timedelta(days=1)
 
         if "T" in start_date_str:

--- a/src/gcal/gcal_service.py
+++ b/src/gcal/gcal_service.py
@@ -37,7 +37,9 @@ class GoogleService:
             self.logger.debug("Google Calendar connection test passed.")
             return True
         except HttpError as e:
-            self.logger.error(f"Google API error: {e}. Please click 'view settings' and re-authorize")
+            self.logger.error(
+                f"Google API error: {e}. Please click 'view settings' and re-authorize"
+            )
             return False
         except Exception as e:
             self.logger.error(f"Google Calendar Connection test failed: {e}")
@@ -66,7 +68,9 @@ class GoogleService:
 
                     if page_token:
                         if page_token in seen_page_tokens:
-                            raise RuntimeError(f"Repeated Google Calendar page token detected for calendar ID {cal_id}")
+                            raise RuntimeError(
+                                f"Repeated Google Calendar page token detected for calendar ID {cal_id}"
+                            )
                         seen_page_tokens.add(page_token)
 
                     params = {
@@ -94,8 +98,8 @@ class GoogleService:
 
                         if not item.get("start"):
                             self.logger.warning(
-                                f"Skipping event with missing start field: id={item.get('id')} "
-                                f"summary={item.get('summary', '')!r}"
+                                "Skipping event with missing start field: id=%s",
+                                item.get("id"),
                             )
                             cal_skipped += 1
                             continue
@@ -127,7 +131,9 @@ class GoogleService:
             self.logger.exception("Error retrieving Google Calendar events")
             raise
 
-    def update_gcal_event(self, notion_task, existing_gcal_cal_id, existing_gcal_event_id):
+    def update_gcal_event(
+        self, notion_task, existing_gcal_cal_id, existing_gcal_event_id
+    ):
         event = self.make_event_body(notion_task)
         self.service.events().patch(
             calendarId=existing_gcal_cal_id, eventId=existing_gcal_event_id, body=event
@@ -137,27 +143,41 @@ class GoogleService:
         if new_gcal_calendar_id is None:
             new_gcal_calendar_id = self.notion_setting["gcal_default_id"]
         event = self.make_event_body(notion_task)
-        gcal_event = self.service.events().insert(calendarId=new_gcal_calendar_id, body=event).execute()
+        gcal_event = (
+            self.service.events()
+            .insert(calendarId=new_gcal_calendar_id, body=event)
+            .execute()
+        )
         # get the event id and update the notion task by query page id
         event_id = gcal_event.get("id")
         return event_id
 
     def move_and_update_gcal_event(
-        self, notion_task, existing_gcal_event_id, new_gcal_calendar_id, existing_gcal_cal_id
+        self,
+        notion_task,
+        existing_gcal_event_id,
+        new_gcal_calendar_id,
+        existing_gcal_cal_id,
     ):
         self.service.events().move(
             calendarId=existing_gcal_cal_id,
             eventId=existing_gcal_event_id,
             destination=new_gcal_calendar_id,
         ).execute()
-        self.update_gcal_event(notion_task, new_gcal_calendar_id, existing_gcal_event_id)
+        self.update_gcal_event(
+            notion_task, new_gcal_calendar_id, existing_gcal_event_id
+        )
 
     def delete_gcal_event(self, gcal_calendar_id, gcal_event_id):
         try:
-            self.service.events().delete(calendarId=gcal_calendar_id, eventId=gcal_event_id).execute()
+            self.service.events().delete(
+                calendarId=gcal_calendar_id, eventId=gcal_event_id
+            ).execute()
             self.logger.info(f"Successfully deleted event with ID: {gcal_event_id}")
         except Exception as e:
-            self.logger.error(f"An error occurred while deleting event with ID: {gcal_event_id}: {e}")
+            self.logger.error(
+                f"An error occurred while deleting event with ID: {gcal_event_id}: {e}"
+            )
 
     def make_event_body(self, notion_task):
         # set icone and task name
@@ -198,7 +218,9 @@ class GoogleService:
             .get("end", "")
         )
         # Adjust and convert dates to UTC
-        event_start_date, event_end_date = self.adjust_notion_dates(notion_task_start_date, notion_task_end_date)
+        event_start_date, event_end_date = self.adjust_notion_dates(
+            notion_task_start_date, notion_task_end_date
+        )
 
         # set location
         try:
@@ -273,8 +295,12 @@ class GoogleService:
             end_date = start_date
 
         if "T" in start_date_str and end_date == start_date:  # datetime format
-            end_date = start_date + timedelta(minutes=int(self.notion_setting["default_event_length"]))
-        elif "T" not in start_date_str:  # date format: Google Calendar end date is exclusive, always add 1 day
+            end_date = start_date + timedelta(
+                minutes=int(self.notion_setting["default_event_length"])
+            )
+        elif (
+            "T" not in start_date_str
+        ):  # date format: Google Calendar end date is exclusive, always add 1 day
             end_date = end_date + timedelta(days=1)
 
         if "T" in start_date_str:

--- a/src/gcal/gcal_token.py
+++ b/src/gcal/gcal_token.py
@@ -59,16 +59,12 @@ class GoogleToken:
                     access_token = decrypt_token(data.get("accessToken"))
                     refresh_token = decrypt_token(data.get("refreshToken"))
                 except TokenCryptoError as e:
-                    raise SettingError(
-                        f"Failed to decrypt encrypted Google OAuth token: {e}"
-                    ) from e
+                    raise SettingError(f"Failed to decrypt encrypted Google OAuth token: {e}") from e
 
                 self._assert_plaintext_runtime_token("accessToken", access_token)
                 self._assert_plaintext_runtime_token("refreshToken", refresh_token)
 
-                client_secret_ssm_path = os.environ.get(
-                    "GOOGLE_CALENDAR_CLIENT_SECRET_SSM_PATH", ""
-                ).strip()
+                client_secret_ssm_path = os.environ.get("GOOGLE_CALENDAR_CLIENT_SECRET_SSM_PATH", "").strip()
                 if not client_secret_ssm_path:
                     raise SettingError(
                         "GOOGLE_CALENDAR_CLIENT_SECRET_SSM_PATH env var is required but not set in APP_MODE=cloud."
@@ -76,17 +72,13 @@ class GoogleToken:
                 try:
                     client_secret = get_ssm_parameter(client_secret_ssm_path)
                 except SSMSecretError as e:
-                    raise SettingError(
-                        f"Failed to resolve Google client secret from SSM: {e}"
-                    ) from e
+                    raise SettingError(f"Failed to resolve Google client secret from SSM: {e}") from e
                 credentials_data = {
                     "token": access_token,
                     "refresh_token": refresh_token,
                     "token_uri": _DEFAULT_TOKEN_URI,
                     "scopes": list(_DEFAULT_SCOPES),
-                    "expiry": self._convert_google_expiry_date_format(
-                        data.get("expiryDate")
-                    ),
+                    "expiry": self._convert_google_expiry_date_format(data.get("expiryDate")),
                     "client_id": os.environ.get("GOOGLE_CALENDAR_CLIENT_ID"),
                     "client_secret": client_secret,
                 }
@@ -96,14 +88,10 @@ class GoogleToken:
             except SettingError:
                 raise
             except Exception as e:
-                raise SettingError(
-                    f"Error loading Google credentials from DynamoDB: {e}"
-                ) from e
+                raise SettingError(f"Error loading Google credentials from DynamoDB: {e}") from e
         if self.mode == "local":
             return self._load_local_credentials()
-        raise SettingError(
-            f"Unknown config mode '{self.mode}'. Expected 'cloud' or 'local'."
-        )
+        raise SettingError(f"Unknown config mode '{self.mode}'. Expected 'cloud' or 'local'.")
 
     def _load_local_credentials(self):
         client_id = os.environ.get("GOOGLE_CLIENT_ID", "").strip()
@@ -120,15 +108,11 @@ class GoogleToken:
             if not val
         ]
         if missing:
-            raise SettingError(
-                f"Required environment variables for local Google auth are missing or empty: {missing}"
-            )
+            raise SettingError(f"Required environment variables for local Google auth are missing or empty: {missing}")
         try:
             refresh_token = decrypt_token_if_encrypted(refresh_token)
         except TokenCryptoError as e:
-            raise SettingError(
-                f"Failed to decrypt encrypted Google OAuth token: {e}"
-            ) from e
+            raise SettingError(f"Failed to decrypt encrypted Google OAuth token: {e}") from e
         self._assert_plaintext_runtime_token("refreshToken", refresh_token)
 
         token_uri = os.environ.get("GOOGLE_TOKEN_URI", "").strip() or _DEFAULT_TOKEN_URI
@@ -137,9 +121,7 @@ class GoogleToken:
         if scopes_raw:
             scopes = [s.strip() for s in scopes_raw.split(",") if s.strip()]
             if not scopes:
-                raise SettingError(
-                    "GOOGLE_SCOPES is set but resulted in an empty scope list after parsing."
-                )
+                raise SettingError("GOOGLE_SCOPES is set but resulted in an empty scope list after parsing.")
         else:
             scopes = list(_DEFAULT_SCOPES)
 
@@ -167,9 +149,7 @@ class GoogleToken:
                     "Failed to refresh Google credentials in local mode. "
                     "GOOGLE_REFRESH_TOKEN is likely invalid/expired; renew it outside runtime and update .env.local."
                 ) from e
-            raise RefreshError(
-                "Failed to refresh Google credentials. Refresh token is likely invalid/expired."
-            ) from e
+            raise RefreshError("Failed to refresh Google credentials. Refresh token is likely invalid/expired.") from e
 
     def _save_credentials(self, credentials):
         try:
@@ -220,9 +200,7 @@ class GoogleToken:
 
     def _assert_plaintext_runtime_token(self, token_name, value):
         if isinstance(value, str) and value.startswith(TOKEN_ENCRYPTION_PREFIX):
-            raise SettingError(
-                f"Internal token handling error: {token_name} remained encrypted at runtime."
-            )
+            raise SettingError(f"Internal token handling error: {token_name} remained encrypted at runtime.")
 
 
 if __name__ == "__main__":

--- a/src/gcal/gcal_token.py
+++ b/src/gcal/gcal_token.py
@@ -4,7 +4,7 @@ from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google.auth.exceptions import RefreshError
 from utils.ssm_secrets import SSMSecretError, get_ssm_parameter
-from utils.token_crypto import TOKEN_ENCRYPTION_PREFIX, TokenCryptoError, decrypt_token_if_encrypted
+from utils.token_crypto import TOKEN_ENCRYPTION_PREFIX, TokenCryptoError, decrypt_token, decrypt_token_if_encrypted
 
 _DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token"
 _DEFAULT_SCOPES = [
@@ -51,8 +51,8 @@ class GoogleToken:
                 self.logger.debug("Loading credentials from DynamoDB")
                 data = get_google_token_by_uuid(self.config.get("uuid"))
                 try:
-                    access_token = decrypt_token_if_encrypted(data.get("accessToken"))
-                    refresh_token = decrypt_token_if_encrypted(data.get("refreshToken"))
+                    access_token = decrypt_token(data.get("accessToken"))
+                    refresh_token = decrypt_token(data.get("refreshToken"))
                 except TokenCryptoError as e:
                     raise SettingError(f"Failed to decrypt encrypted Google OAuth token: {e}") from e
 

--- a/src/gcal/gcal_token.py
+++ b/src/gcal/gcal_token.py
@@ -4,7 +4,12 @@ from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google.auth.exceptions import RefreshError
 from utils.ssm_secrets import SSMSecretError, get_ssm_parameter
-from utils.token_crypto import TOKEN_ENCRYPTION_PREFIX, TokenCryptoError, decrypt_token, decrypt_token_if_encrypted
+from utils.token_crypto import (
+    TOKEN_ENCRYPTION_PREFIX,
+    TokenCryptoError,
+    decrypt_token,
+    decrypt_token_if_encrypted,
+)
 
 _DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token"
 _DEFAULT_SCOPES = [
@@ -54,12 +59,16 @@ class GoogleToken:
                     access_token = decrypt_token(data.get("accessToken"))
                     refresh_token = decrypt_token(data.get("refreshToken"))
                 except TokenCryptoError as e:
-                    raise SettingError(f"Failed to decrypt encrypted Google OAuth token: {e}") from e
+                    raise SettingError(
+                        f"Failed to decrypt encrypted Google OAuth token: {e}"
+                    ) from e
 
                 self._assert_plaintext_runtime_token("accessToken", access_token)
                 self._assert_plaintext_runtime_token("refreshToken", refresh_token)
 
-                client_secret_ssm_path = os.environ.get("GOOGLE_CALENDAR_CLIENT_SECRET_SSM_PATH", "").strip()
+                client_secret_ssm_path = os.environ.get(
+                    "GOOGLE_CALENDAR_CLIENT_SECRET_SSM_PATH", ""
+                ).strip()
                 if not client_secret_ssm_path:
                     raise SettingError(
                         "GOOGLE_CALENDAR_CLIENT_SECRET_SSM_PATH env var is required but not set in APP_MODE=cloud."
@@ -67,13 +76,17 @@ class GoogleToken:
                 try:
                     client_secret = get_ssm_parameter(client_secret_ssm_path)
                 except SSMSecretError as e:
-                    raise SettingError(f"Failed to resolve Google client secret from SSM: {e}") from e
+                    raise SettingError(
+                        f"Failed to resolve Google client secret from SSM: {e}"
+                    ) from e
                 credentials_data = {
                     "token": access_token,
                     "refresh_token": refresh_token,
                     "token_uri": _DEFAULT_TOKEN_URI,
                     "scopes": list(_DEFAULT_SCOPES),
-                    "expiry": self._convert_google_expiry_date_format(data.get("expiryDate")),
+                    "expiry": self._convert_google_expiry_date_format(
+                        data.get("expiryDate")
+                    ),
                     "client_id": os.environ.get("GOOGLE_CALENDAR_CLIENT_ID"),
                     "client_secret": client_secret,
                 }
@@ -83,10 +96,14 @@ class GoogleToken:
             except SettingError:
                 raise
             except Exception as e:
-                raise SettingError(f"Error loading Google credentials from DynamoDB: {e}") from e
+                raise SettingError(
+                    f"Error loading Google credentials from DynamoDB: {e}"
+                ) from e
         if self.mode == "local":
             return self._load_local_credentials()
-        raise SettingError(f"Unknown config mode '{self.mode}'. Expected 'cloud' or 'local'.")
+        raise SettingError(
+            f"Unknown config mode '{self.mode}'. Expected 'cloud' or 'local'."
+        )
 
     def _load_local_credentials(self):
         client_id = os.environ.get("GOOGLE_CLIENT_ID", "").strip()
@@ -103,11 +120,15 @@ class GoogleToken:
             if not val
         ]
         if missing:
-            raise SettingError(f"Required environment variables for local Google auth are missing or empty: {missing}")
+            raise SettingError(
+                f"Required environment variables for local Google auth are missing or empty: {missing}"
+            )
         try:
             refresh_token = decrypt_token_if_encrypted(refresh_token)
         except TokenCryptoError as e:
-            raise SettingError(f"Failed to decrypt encrypted Google OAuth token: {e}") from e
+            raise SettingError(
+                f"Failed to decrypt encrypted Google OAuth token: {e}"
+            ) from e
         self._assert_plaintext_runtime_token("refreshToken", refresh_token)
 
         token_uri = os.environ.get("GOOGLE_TOKEN_URI", "").strip() or _DEFAULT_TOKEN_URI
@@ -116,7 +137,9 @@ class GoogleToken:
         if scopes_raw:
             scopes = [s.strip() for s in scopes_raw.split(",") if s.strip()]
             if not scopes:
-                raise SettingError("GOOGLE_SCOPES is set but resulted in an empty scope list after parsing.")
+                raise SettingError(
+                    "GOOGLE_SCOPES is set but resulted in an empty scope list after parsing."
+                )
         else:
             scopes = list(_DEFAULT_SCOPES)
 
@@ -144,7 +167,9 @@ class GoogleToken:
                     "Failed to refresh Google credentials in local mode. "
                     "GOOGLE_REFRESH_TOKEN is likely invalid/expired; renew it outside runtime and update .env.local."
                 ) from e
-            raise RefreshError("Failed to refresh Google credentials. Refresh token is likely invalid/expired.") from e
+            raise RefreshError(
+                "Failed to refresh Google credentials. Refresh token is likely invalid/expired."
+            ) from e
 
     def _save_credentials(self, credentials):
         try:
@@ -195,7 +220,9 @@ class GoogleToken:
 
     def _assert_plaintext_runtime_token(self, token_name, value):
         if isinstance(value, str) and value.startswith(TOKEN_ENCRYPTION_PREFIX):
-            raise SettingError(f"Internal token handling error: {token_name} remained encrypted at runtime.")
+            raise SettingError(
+                f"Internal token handling error: {token_name} remained encrypted at runtime."
+            )
 
 
 if __name__ == "__main__":

--- a/src/notion/notion_service.py
+++ b/src/notion/notion_service.py
@@ -20,17 +20,11 @@ class NotionService:
         self.token = token
         self.setting = user_setting
         self.page_property = self.setting["page_property"]
-        self.notion_api_version = self.setting.get(
-            "notion_api_version", NOTION_API_VERSION_2022
-        )
+        self.notion_api_version = self.setting.get("notion_api_version", NOTION_API_VERSION_2022)
 
         try:
-            self.client = Client(
-                auth=self.token, notion_version=self.notion_api_version
-            )
-            self.logger.debug(
-                f"Notion client initialized successfully with API version {self.notion_api_version}."
-            )
+            self.client = Client(auth=self.token, notion_version=self.notion_api_version)
+            self.logger.debug(f"Notion client initialized successfully with API version {self.notion_api_version}.")
         except Exception as e:
             self.logger.error(f"Failed to initialize Notion client: {e}")
             raise SettingError(f"Failed to initialize Notion client: {e}")
@@ -41,14 +35,10 @@ class NotionService:
             self.logger.info("Notion connection passed.")
             return True
         except APIResponseError as e:
-            self.logger.error(
-                f"Notion API error: {e}. Please click 'view settings' and re-authorize the integration."
-            )
+            self.logger.error(f"Notion API error: {e}. Please click 'view settings' and re-authorize the integration.")
             return False
         except Exception as e:
-            self.logger.error(
-                f"Notion Connection failed: {e}. Please check your network connection."
-            )
+            self.logger.error(f"Notion Connection failed: {e}. Please check your network connection.")
             return False
 
     def _query_database_with_pagination(self, **query_kwargs):
@@ -56,9 +46,7 @@ class NotionService:
         next_cursor = None
         page_number = 0
         database_id = query_kwargs["database_id"]
-        request_body = {
-            key: value for key, value in query_kwargs.items() if key != "database_id"
-        }
+        request_body = {key: value for key, value in query_kwargs.items() if key != "database_id"}
 
         while True:
             page_number += 1
@@ -90,12 +78,8 @@ class NotionService:
     def get_notion_task(self):
 
         # TODO: Notion has no filter for start date and end date so add extra column: GCAL_END_DATE_NOTION_NAME
-        before_date_with_time_zone = (
-            self.setting["before_date"] + "T00:00:00.000" + self.setting["timecode"]
-        )
-        after_date_with_time_zone = (
-            self.setting["after_date"] + "T00:00:00.000" + self.setting["timecode"]
-        )
+        before_date_with_time_zone = self.setting["before_date"] + "T00:00:00.000" + self.setting["timecode"]
+        after_date_with_time_zone = self.setting["after_date"] + "T00:00:00.000" + self.setting["timecode"]
         date_range = f"from {self.setting['after_date']} (inclusive) to {self.setting['before_date']} (exclusive)"
         notion_summary = {
             "action": "get_notion_task",
@@ -118,12 +102,8 @@ class NotionService:
                                 "date": {"before": before_date_with_time_zone},
                             },
                             {
-                                "property": self.page_property[
-                                    "GCal_End_Date_Notion_Name"
-                                ],
-                                "formula": {
-                                    "date": {"on_or_after": after_date_with_time_zone}
-                                },
+                                "property": self.page_property["GCal_End_Date_Notion_Name"],
+                                "formula": {"date": {"on_or_after": after_date_with_time_zone}},
                             },
                         ]
                     },
@@ -136,9 +116,7 @@ class NotionService:
 
     def get_notion_task_by_gcal_event_id(self, gcal_event_id):
         try:
-            self.logger.info(
-                f"Reading Notion database by Google event ID: {gcal_event_id}"
-            )
+            self.logger.info(f"Reading Notion database by Google event ID: {gcal_event_id}")
             return self._query_database_with_pagination(
                 database_id=self.setting["database_id"],
                 filter={
@@ -150,9 +128,7 @@ class NotionService:
             self.logger.error(f"Error reading Notion table: {e}")
             return None
 
-    def update_notion_task(
-        self, page_id, gcal_event, gcal_cal_name, new_gcal_sync_time
-    ):
+    def update_notion_task(self, page_id, gcal_event, gcal_cal_name, new_gcal_sync_time):
         """
         Update a Notion task with Google Calendar event details.
 
@@ -177,9 +153,7 @@ class NotionService:
             properties={
                 self.page_property["Task_Notion_Name"]: {
                     "type": "title",
-                    "title": [
-                        {"type": "text", "text": {"content": summary_without_emojis}}
-                    ],
+                    "title": [{"type": "text", "text": {"content": summary_without_emojis}}],
                 },
                 self.page_property["Date_Notion_Name"]: {
                     "type": "date",
@@ -190,9 +164,7 @@ class NotionService:
                 },
                 self.page_property["ExtraInfo_Notion_Name"]: {
                     "type": "rich_text",
-                    "rich_text": [
-                        {"text": {"content": gcal_event.get("description", "")}}
-                    ],
+                    "rich_text": [{"text": {"content": gcal_event.get("description", "")}}],
                 },
                 self.page_property["Location_Notion_Name"]: {
                     "type": "place",
@@ -282,9 +254,7 @@ class NotionService:
                 },
                 self.page_property["ExtraInfo_Notion_Name"]: {
                     "type": "rich_text",
-                    "rich_text": [
-                        {"text": {"content": gcal_event.get("description", "")}}
-                    ],
+                    "rich_text": [{"text": {"content": gcal_event.get("description", "")}}],
                 },
                 self.page_property["Location_Notion_Name"]: {
                     "type": "place",
@@ -303,9 +273,7 @@ class NotionService:
                 },
             },
         )
-        self.logger.info(
-            "Created Notion task for Google Calendar event_id=%s", gcal_event.get("id")
-        )
+        self.logger.info("Created Notion task for Google Calendar event_id=%s", gcal_event.get("id"))
 
     def delete_notion_task(self, page_id):
         self.client.pages.update(
@@ -327,9 +295,7 @@ class NotionService:
     def parse_date_in_notion_format(self, date_obj):
         """Helper function to notion format dates."""
         try:
-            formatted_date = date_obj.strftime(
-                f"%Y-%m-%dT%H:%M:%S{self.setting['timecode']}"
-            )
+            formatted_date = date_obj.strftime(f"%Y-%m-%dT%H:%M:%S{self.setting['timecode']}")
         except Exception as e:
             self.logger.error(f"Error formatting date: {e}")
             formatted_date = None
@@ -396,9 +362,7 @@ if __name__ == "__main__":
 
     with log_path.open("w") as output:
         notion_summary, notion_tasks = ns.get_notion_task()
-        json.dump(
-            {"summary": notion_summary, "results": notion_tasks}, output, indent=4
-        )
+        json.dump({"summary": notion_summary, "results": notion_tasks}, output, indent=4)
     logging.info(
         f"Notion Task Count. {len(notion_tasks)}, from {ns.page_property['GCal_End_Date_Notion_Name']}: {ns.setting['after_date']} "  # noqa: E501
         f"to {ns.page_property['Date_Notion_Name']}: {ns.setting['before_date']} (exclusive)"

--- a/src/notion/notion_service.py
+++ b/src/notion/notion_service.py
@@ -20,11 +20,17 @@ class NotionService:
         self.token = token
         self.setting = user_setting
         self.page_property = self.setting["page_property"]
-        self.notion_api_version = self.setting.get("notion_api_version", NOTION_API_VERSION_2022)
+        self.notion_api_version = self.setting.get(
+            "notion_api_version", NOTION_API_VERSION_2022
+        )
 
         try:
-            self.client = Client(auth=self.token, notion_version=self.notion_api_version)
-            self.logger.debug(f"Notion client initialized successfully with API version {self.notion_api_version}.")
+            self.client = Client(
+                auth=self.token, notion_version=self.notion_api_version
+            )
+            self.logger.debug(
+                f"Notion client initialized successfully with API version {self.notion_api_version}."
+            )
         except Exception as e:
             self.logger.error(f"Failed to initialize Notion client: {e}")
             raise SettingError(f"Failed to initialize Notion client: {e}")
@@ -35,10 +41,14 @@ class NotionService:
             self.logger.info("Notion connection passed.")
             return True
         except APIResponseError as e:
-            self.logger.error(f"Notion API error: {e}. Please click 'view settings' and re-authorize the integration.")
+            self.logger.error(
+                f"Notion API error: {e}. Please click 'view settings' and re-authorize the integration."
+            )
             return False
         except Exception as e:
-            self.logger.error(f"Notion Connection failed: {e}. Please check your network connection.")
+            self.logger.error(
+                f"Notion Connection failed: {e}. Please check your network connection."
+            )
             return False
 
     def _query_database_with_pagination(self, **query_kwargs):
@@ -46,7 +56,9 @@ class NotionService:
         next_cursor = None
         page_number = 0
         database_id = query_kwargs["database_id"]
-        request_body = {key: value for key, value in query_kwargs.items() if key != "database_id"}
+        request_body = {
+            key: value for key, value in query_kwargs.items() if key != "database_id"
+        }
 
         while True:
             page_number += 1
@@ -78,8 +90,12 @@ class NotionService:
     def get_notion_task(self):
 
         # TODO: Notion has no filter for start date and end date so add extra column: GCAL_END_DATE_NOTION_NAME
-        before_date_with_time_zone = self.setting["before_date"] + "T00:00:00.000" + self.setting["timecode"]
-        after_date_with_time_zone = self.setting["after_date"] + "T00:00:00.000" + self.setting["timecode"]
+        before_date_with_time_zone = (
+            self.setting["before_date"] + "T00:00:00.000" + self.setting["timecode"]
+        )
+        after_date_with_time_zone = (
+            self.setting["after_date"] + "T00:00:00.000" + self.setting["timecode"]
+        )
         date_range = f"from {self.setting['after_date']} (inclusive) to {self.setting['before_date']} (exclusive)"
         notion_summary = {
             "action": "get_notion_task",
@@ -102,8 +118,12 @@ class NotionService:
                                 "date": {"before": before_date_with_time_zone},
                             },
                             {
-                                "property": self.page_property["GCal_End_Date_Notion_Name"],
-                                "formula": {"date": {"on_or_after": after_date_with_time_zone}},
+                                "property": self.page_property[
+                                    "GCal_End_Date_Notion_Name"
+                                ],
+                                "formula": {
+                                    "date": {"on_or_after": after_date_with_time_zone}
+                                },
                             },
                         ]
                     },
@@ -116,7 +136,9 @@ class NotionService:
 
     def get_notion_task_by_gcal_event_id(self, gcal_event_id):
         try:
-            self.logger.info(f"Reading Notion database by Google event ID: {gcal_event_id}")
+            self.logger.info(
+                f"Reading Notion database by Google event ID: {gcal_event_id}"
+            )
             return self._query_database_with_pagination(
                 database_id=self.setting["database_id"],
                 filter={
@@ -128,7 +150,9 @@ class NotionService:
             self.logger.error(f"Error reading Notion table: {e}")
             return None
 
-    def update_notion_task(self, page_id, gcal_event, gcal_cal_name, new_gcal_sync_time):
+    def update_notion_task(
+        self, page_id, gcal_event, gcal_cal_name, new_gcal_sync_time
+    ):
         """
         Update a Notion task with Google Calendar event details.
 
@@ -153,7 +177,9 @@ class NotionService:
             properties={
                 self.page_property["Task_Notion_Name"]: {
                     "type": "title",
-                    "title": [{"type": "text", "text": {"content": summary_without_emojis}}],
+                    "title": [
+                        {"type": "text", "text": {"content": summary_without_emojis}}
+                    ],
                 },
                 self.page_property["Date_Notion_Name"]: {
                     "type": "date",
@@ -164,11 +190,17 @@ class NotionService:
                 },
                 self.page_property["ExtraInfo_Notion_Name"]: {
                     "type": "rich_text",
-                    "rich_text": [{"text": {"content": gcal_event.get("description", "")}}],
+                    "rich_text": [
+                        {"text": {"content": gcal_event.get("description", "")}}
+                    ],
                 },
                 self.page_property["Location_Notion_Name"]: {
                     "type": "place",
-                    "place": {"lat": 0, "lon": 0, "address": gcal_event.get("location", "")},
+                    "place": {
+                        "lat": 0,
+                        "lon": 0,
+                        "address": gcal_event.get("location", ""),
+                    },
                 },
                 self.page_property["GCal_Sync_Time_Notion_Name"]: {
                     "type": "rich_text",
@@ -250,11 +282,17 @@ class NotionService:
                 },
                 self.page_property["ExtraInfo_Notion_Name"]: {
                     "type": "rich_text",
-                    "rich_text": [{"text": {"content": gcal_event.get("description", "")}}],
+                    "rich_text": [
+                        {"text": {"content": gcal_event.get("description", "")}}
+                    ],
                 },
                 self.page_property["Location_Notion_Name"]: {
                     "type": "place",
-                    "place": {"lat": 0, "lon": 0, "address": gcal_event.get("location", "")},
+                    "place": {
+                        "lat": 0,
+                        "lon": 0,
+                        "address": gcal_event.get("location", ""),
+                    },
                 },
                 self.page_property["GCal_EventId_Notion_Name"]: {
                     "type": "rich_text",
@@ -265,7 +303,9 @@ class NotionService:
                 },
             },
         )
-        self.logger.info(f"Event {gcal_event.get('summary', '')} created in Notion successfully.")
+        self.logger.info(
+            "Created Notion task for Google Calendar event_id=%s", gcal_event.get("id")
+        )
 
     def delete_notion_task(self, page_id):
         self.client.pages.update(
@@ -287,7 +327,9 @@ class NotionService:
     def parse_date_in_notion_format(self, date_obj):
         """Helper function to notion format dates."""
         try:
-            formatted_date = date_obj.strftime(f"%Y-%m-%dT%H:%M:%S{self.setting['timecode']}")
+            formatted_date = date_obj.strftime(
+                f"%Y-%m-%dT%H:%M:%S{self.setting['timecode']}"
+            )
         except Exception as e:
             self.logger.error(f"Error formatting date: {e}")
             formatted_date = None
@@ -354,7 +396,9 @@ if __name__ == "__main__":
 
     with log_path.open("w") as output:
         notion_summary, notion_tasks = ns.get_notion_task()
-        json.dump({"summary": notion_summary, "results": notion_tasks}, output, indent=4)
+        json.dump(
+            {"summary": notion_summary, "results": notion_tasks}, output, indent=4
+        )
     logging.info(
         f"Notion Task Count. {len(notion_tasks)}, from {ns.page_property['GCal_End_Date_Notion_Name']}: {ns.setting['after_date']} "  # noqa: E501
         f"to {ns.page_property['Date_Notion_Name']}: {ns.setting['before_date']} (exclusive)"

--- a/src/notion/notion_token.py
+++ b/src/notion/notion_token.py
@@ -38,22 +38,16 @@ class NotionToken:
             except SettingError:
                 raise
             except Exception as e:
-                raise SettingError(
-                    f"Error loading Notion token from DynamoDB: {e}"
-                ) from e
+                raise SettingError(f"Error loading Notion token from DynamoDB: {e}") from e
         if self.mode == "local":
             token = os.environ.get("NOTION_TOKEN", "").strip()
             if not token:
-                raise SettingError(
-                    "NOTION_TOKEN environment variable is required in local mode but is not set."
-                )
+                raise SettingError("NOTION_TOKEN environment variable is required in local mode but is not set.")
             try:
                 return decrypt_token_if_encrypted(token)
             except TokenCryptoError as e:
                 raise SettingError(f"Failed to decrypt Notion token: {e}") from e
-        raise SettingError(
-            f"Unknown config mode '{self.mode}'. Expected 'cloud' or 'local'."
-        )
+        raise SettingError(f"Unknown config mode '{self.mode}'. Expected 'cloud' or 'local'.")
 
     def get(self):
         return self.token

--- a/src/notion/notion_token.py
+++ b/src/notion/notion_token.py
@@ -1,5 +1,9 @@
 import os
-from utils.token_crypto import TokenCryptoError, decrypt_token, decrypt_token_if_encrypted
+from utils.token_crypto import (
+    TokenCryptoError,
+    decrypt_token,
+    decrypt_token_if_encrypted,
+)
 
 
 class SettingError(Exception):
@@ -34,16 +38,22 @@ class NotionToken:
             except SettingError:
                 raise
             except Exception as e:
-                raise SettingError(f"Error loading Notion token from DynamoDB: {e}") from e
+                raise SettingError(
+                    f"Error loading Notion token from DynamoDB: {e}"
+                ) from e
         if self.mode == "local":
             token = os.environ.get("NOTION_TOKEN", "").strip()
             if not token:
-                raise SettingError("NOTION_TOKEN environment variable is required in local mode but is not set.")
+                raise SettingError(
+                    "NOTION_TOKEN environment variable is required in local mode but is not set."
+                )
             try:
                 return decrypt_token_if_encrypted(token)
             except TokenCryptoError as e:
                 raise SettingError(f"Failed to decrypt Notion token: {e}") from e
-        raise SettingError(f"Unknown config mode '{self.mode}'. Expected 'cloud' or 'local'.")
+        raise SettingError(
+            f"Unknown config mode '{self.mode}'. Expected 'cloud' or 'local'."
+        )
 
     def get(self):
         return self.token

--- a/src/notion/notion_token.py
+++ b/src/notion/notion_token.py
@@ -1,5 +1,5 @@
 import os
-from utils.token_crypto import TokenCryptoError, decrypt_token_if_encrypted
+from utils.token_crypto import TokenCryptoError, decrypt_token, decrypt_token_if_encrypted
 
 
 class SettingError(Exception):
@@ -28,7 +28,7 @@ class NotionToken:
 
                 response = get_notion_token_by_uuid(uuid)
                 try:
-                    return decrypt_token_if_encrypted(response.get("accessToken"))
+                    return decrypt_token(response.get("accessToken"))
                 except TokenCryptoError as e:
                     raise SettingError(f"Failed to decrypt Notion token: {e}") from e
             except SettingError:

--- a/src/sync/sync.py
+++ b/src/sync/sync.py
@@ -11,9 +11,7 @@ logger = get_logger(__name__)
 
 # Cap sync volume to avoid unbounded processing for large datasets.
 SYNC_TASK_LIMIT = 250
-SAFE_SYNC_FAILURE_MESSAGE = (
-    "Sync failed. See Lambda logs with aws_request_id for details."
-)
+SAFE_SYNC_FAILURE_MESSAGE = "Sync failed. See Lambda logs with aws_request_id for details."
 
 
 class SyncAbortError(Exception):
@@ -29,13 +27,9 @@ def compare_timezones(notion_time_str, google_time_str):
 
     notion_timezone = notion_time.tzinfo
     google_timezone = google_time.tzinfo
-    logger.debug(
-        f"Notion Timezone: {notion_timezone}, Google Calendar Timezone: {google_timezone}"
-    )
+    logger.debug(f"Notion Timezone: {notion_timezone}, Google Calendar Timezone: {google_timezone}")
     if notion_timezone != google_timezone:
-        raise SyncAbortError(
-            f"Timezones are different: Notion {notion_timezone} and Google Calendar {google_timezone}"
-        )
+        raise SyncAbortError(f"Timezones are different: Notion {notion_timezone} and Google Calendar {google_timezone}")
 
 
 def get_current_time_in_iso_format():
@@ -63,9 +57,7 @@ def get_gcal_event_from_list(gcal_event_list, gcal_event_id):
         if gcal_event.get("id") == gcal_event_id:
             return gcal_event
 
-    logger.debug(
-        f"Google Calendar event '{gcal_event_id}' not found in the provided list"
-    )
+    logger.debug(f"Google Calendar event '{gcal_event_id}' not found in the provided list")
     return None
 
 
@@ -149,9 +141,7 @@ def synchronize_notion_and_google_calendar(
                 }
             # No Notion tasks found and no Google Calendar events found
             if task_count == 0 and event_count == 0:
-                logger.debug(
-                    "No Notion tasks found and no Google Calendar events found."
-                )
+                logger.debug("No Notion tasks found and no Google Calendar events found.")
                 return {
                     "statusCode": 200,
                     "body": {
@@ -186,18 +176,10 @@ def synchronize_notion_and_google_calendar(
                 if not notion_gcal_cal_name:
                     notion_gcal_cal_name = user_setting["gcal_default_name"]
                     notion_gcal_cal_id = user_setting["gcal_default_id"]
-                    logger.warning(
-                        f"Calendar name not found. Use the default calendar: {notion_gcal_cal_name}"
-                    )
-                    logger.debug(
-                        f"Calendar id not found. Use the default calendar id: {notion_gcal_cal_id}"
-                    )
-                    logger.info(
-                        "Update Notion Task for default calendar id and calendar name"
-                    )
-                    notion_service.update_notion_task_for_default_calendar(
-                        notion_task_page_id, notion_gcal_cal_name
-                    )
+                    logger.warning(f"Calendar name not found. Use the default calendar: {notion_gcal_cal_name}")
+                    logger.debug(f"Calendar id not found. Use the default calendar id: {notion_gcal_cal_id}")
+                    logger.info("Update Notion Task for default calendar id and calendar name")
+                    notion_service.update_notion_task_for_default_calendar(notion_task_page_id, notion_gcal_cal_name)
                 else:
                     notion_gcal_cal_id = gcal_name_dict.get(notion_gcal_cal_name)
                     if not notion_gcal_cal_id:
@@ -231,53 +213,31 @@ def synchronize_notion_and_google_calendar(
                 # Notion Task without Google Calendar Event ID - Create a new event in Google Calendar
                 if not notion_gcal_event_id and should_update_google_events:
                     if notion_deletion:
-                        logger.debug(
-                            "Skipping Google Calendar create for task marked deleted."
-                        )
+                        logger.debug("Skipping Google Calendar create for task marked deleted.")
                         continue
                     action = "create_gcal"
-                    logger.debug(
-                        "Creating a new event in Google Calendar for a Notion task."
-                    )
-                    new_gcal_event_id = google_service.create_gcal_event(
-                        notion_task, notion_gcal_cal_id
-                    )
-                    notion_service.update_notion_task_for_new_gcal_event_id(
-                        notion_task_page_id, new_gcal_event_id
-                    )
+                    logger.debug("Creating a new event in Google Calendar for a Notion task.")
+                    new_gcal_event_id = google_service.create_gcal_event(notion_task, notion_gcal_cal_id)
+                    notion_service.update_notion_task_for_new_gcal_event_id(notion_task_page_id, new_gcal_event_id)
                     continue
 
                 # Notion Task with deletion flag - Delete the event in Google Calendar
                 if notion_deletion and notion_gcal_event_id is not None:
                     action = "delete_gcal"
                     logger.debug("Deleting a Google Calendar event for a Notion task.")
-                    google_service.delete_gcal_event(
-                        notion_gcal_cal_id, notion_gcal_event_id
-                    )
+                    google_service.delete_gcal_event(notion_gcal_cal_id, notion_gcal_event_id)
                     notion_service.delete_notion_task(notion_task_page_id)
 
-                    duplicate_notion_task_list = (
-                        notion_service.get_notion_task_by_gcal_event_id(
-                            notion_gcal_event_id
-                        )
-                    )
+                    duplicate_notion_task_list = notion_service.get_notion_task_by_gcal_event_id(notion_gcal_event_id)
                     if duplicate_notion_task_list is not None:
                         for duplicate_notion_task in duplicate_notion_task_list:
                             duplicate_notion_task_page_id = duplicate_notion_task["id"]
-                            logger.debug(
-                                f"Duplicate Notion Task Page ID: {duplicate_notion_task_page_id}"
-                            )
-                            notion_service.delete_notion_task(
-                                duplicate_notion_task_page_id
-                            )
+                            logger.debug(f"Duplicate Notion Task Page ID: {duplicate_notion_task_page_id}")
+                            notion_service.delete_notion_task(duplicate_notion_task_page_id)
 
-                    deleted_gcal_event = get_gcal_event_from_list(
-                        gcal_event_list, notion_gcal_event_id
-                    )
+                    deleted_gcal_event = get_gcal_event_from_list(gcal_event_list, notion_gcal_event_id)
                     if deleted_gcal_event is not None:
-                        remove_gcal_event_from_list(
-                            gcal_event_list, deleted_gcal_event, notion_gcal_event_id
-                        )
+                        remove_gcal_event_from_list(gcal_event_list, deleted_gcal_event, notion_gcal_event_id)
                     continue
 
                 # Notion Task with Google Calendar Event ID - Check if the event is in Google Calendar
@@ -290,10 +250,7 @@ def synchronize_notion_and_google_calendar(
 
                     if notion_gcal_event_id == gcal_event_id:
                         if compare_time:
-                            if (
-                                not notion_task_last_edited_time
-                                or not gcal_event_updated_time
-                            ):
+                            if not notion_task_last_edited_time or not gcal_event_updated_time:
                                 logger.warning(
                                     "Missing last edited or updated time. Skipping sync for task_id=%s event_id=%s",
                                     notion_task_page_id,
@@ -301,9 +258,7 @@ def synchronize_notion_and_google_calendar(
                                 )
                                 continue
 
-                            compare_timezones(
-                                notion_task_last_edited_time, gcal_event_updated_time
-                            )
+                            compare_timezones(notion_task_last_edited_time, gcal_event_updated_time)
 
                             if (
                                 notion_gcal_sync_time
@@ -315,15 +270,12 @@ def synchronize_notion_and_google_calendar(
                                     notion_task_page_id,
                                     gcal_event_id,
                                 )
-                                remove_gcal_event_from_list(
-                                    gcal_event_list, gcal_event, gcal_event_summary
-                                )
+                                remove_gcal_event_from_list(gcal_event_list, gcal_event, gcal_event_summary)
                                 break
 
                         # Update Google Calendar if Notion is newer or force update
                         if should_update_google_events and (
-                            not compare_time
-                            or (notion_task_last_edited_time > gcal_event_updated_time)
+                            not compare_time or (notion_task_last_edited_time > gcal_event_updated_time)
                         ):
                             action = "update_gcal"
                             logger.debug(
@@ -331,9 +283,7 @@ def synchronize_notion_and_google_calendar(
                                 notion_task_page_id,
                                 gcal_event_id,
                             )
-                            logger.debug(
-                                "Updating the Google Calendar event from Notion."
-                            )
+                            logger.debug("Updating the Google Calendar event from Notion.")
                             if notion_gcal_cal_id == gcal_cal_id:
                                 google_service.update_gcal_event(
                                     notion_task,
@@ -356,8 +306,7 @@ def synchronize_notion_and_google_calendar(
                             )
                         # Update Notion if Google Calendar is newer or force update
                         elif should_update_notion_tasks and (
-                            not compare_time
-                            or (notion_task_last_edited_time < gcal_event_updated_time)
+                            not compare_time or (notion_task_last_edited_time < gcal_event_updated_time)
                         ):
                             action = "update_notion"
                             description = gcal_event.get("description") or ""
@@ -373,9 +322,7 @@ def synchronize_notion_and_google_calendar(
                                         ),
                                         notion_task_id=notion_task_page_id,
                                         gcal_event_id=gcal_event_id,
-                                        gcal_event_start=gcal_event.get(
-                                            "start", {}
-                                        ).get("dateTime")
+                                        gcal_event_start=gcal_event.get("start", {}).get("dateTime")
                                         or gcal_event.get("start", {}).get("date"),
                                         retriable=False,
                                     )
@@ -391,9 +338,7 @@ def synchronize_notion_and_google_calendar(
                                     notion_task_page_id,
                                     gcal_event_id,
                                 )
-                                logger.debug(
-                                    "Updating the Notion task from Google Calendar."
-                                )
+                                logger.debug("Updating the Notion task from Google Calendar.")
                                 notion_service.update_notion_task(
                                     notion_task_page_id,
                                     gcal_event,
@@ -401,13 +346,9 @@ def synchronize_notion_and_google_calendar(
                                     current_gcal_sync_time,
                                 )
                         else:
-                            logger.debug(
-                                "Notion task and Google event are already in sync."
-                            )
+                            logger.debug("Notion task and Google event are already in sync.")
 
-                        remove_gcal_event_from_list(
-                            gcal_event_list, gcal_event, gcal_event_summary
-                        )
+                        remove_gcal_event_from_list(gcal_event_list, gcal_event, gcal_event_summary)
                         break
 
             except SyncAbortError:
@@ -423,10 +364,7 @@ def synchronize_notion_and_google_calendar(
                         notion_task_id=notion_task_page_id,
                         gcal_event_id=notion_gcal_event_id,
                         gcal_event_start=(
-                            (
-                                gcal_event.get("start", {}).get("dateTime")
-                                or gcal_event.get("start", {}).get("date")
-                            )
+                            (gcal_event.get("start", {}).get("dateTime") or gcal_event.get("start", {}).get("date"))
                             if "gcal_event" in locals()
                             else None
                         ),
@@ -441,9 +379,7 @@ def synchronize_notion_and_google_calendar(
 
         # Create new tasks in Notion for the remaining Google Calendar events
         if len(gcal_event_list) > 0 and should_update_notion_tasks:
-            logger.debug(
-                f"🟢Google Calendar: Creating new tasks in Notion for {len(gcal_event_list)} events"
-            )
+            logger.debug(f"🟢Google Calendar: Creating new tasks in Notion for {len(gcal_event_list)} events")
             for gcal_event in gcal_event_list:
                 gcal_event_id = gcal_event.get("id")
                 logger.debug(
@@ -463,9 +399,7 @@ def synchronize_notion_and_google_calendar(
                                     "so it was not synced."
                                 ),
                                 gcal_event_id=gcal_event_id,
-                                gcal_event_start=gcal_event.get("start", {}).get(
-                                    "dateTime"
-                                )
+                                gcal_event_start=gcal_event.get("start", {}).get("dateTime")
                                 or gcal_event.get("start", {}).get("date"),
                                 retriable=False,
                             )
@@ -487,9 +421,7 @@ def synchronize_notion_and_google_calendar(
                                     "Syncing this event would corrupt data integrity."
                                 ),
                                 gcal_event_id=gcal_event_id,
-                                gcal_event_start=gcal_event.get("start", {}).get(
-                                    "dateTime"
-                                )
+                                gcal_event_start=gcal_event.get("start", {}).get("dateTime")
                                 or gcal_event.get("start", {}).get("date"),
                                 retriable=False,
                             )
@@ -514,9 +446,7 @@ def synchronize_notion_and_google_calendar(
                             retriable=True,
                         )
                     )
-                    logger.exception(
-                        "Error during create_notion for event_id=%s", gcal_event_id
-                    )
+                    logger.exception("Error during create_notion for event_id=%s", gcal_event_id)
 
     except Exception as e:
         logger.exception("Error during synchronization")
@@ -539,9 +469,7 @@ def synchronize_notion_and_google_calendar(
     return {"statusCode": 200, "body": {"status": "sync_success", "message": message}}
 
 
-def force_update_notion_tasks_by_google_event_and_ignore_time(
-    user_setting, notion_service, google_service
-):
+def force_update_notion_tasks_by_google_event_and_ignore_time(user_setting, notion_service, google_service):
     # -ga
     # Only update notion tasks
     # Do not update google events (Keep the google events as it is)
@@ -556,9 +484,7 @@ def force_update_notion_tasks_by_google_event_and_ignore_time(
     return result
 
 
-def force_update_google_event_by_notion_task_and_ignore_time(
-    user_setting, notion_service, google_service
-):
+def force_update_google_event_by_notion_task_and_ignore_time(user_setting, notion_service, google_service):
     # -na
     # Only update google events
     # Do not update notion tasks (Keep the notion tasks as it is)

--- a/src/sync/sync.py
+++ b/src/sync/sync.py
@@ -11,7 +11,9 @@ logger = get_logger(__name__)
 
 # Cap sync volume to avoid unbounded processing for large datasets.
 SYNC_TASK_LIMIT = 250
-SAFE_SYNC_FAILURE_MESSAGE = "Sync failed. See Lambda logs with aws_request_id for details."
+SAFE_SYNC_FAILURE_MESSAGE = (
+    "Sync failed. See Lambda logs with aws_request_id for details."
+)
 
 
 class SyncAbortError(Exception):
@@ -27,9 +29,13 @@ def compare_timezones(notion_time_str, google_time_str):
 
     notion_timezone = notion_time.tzinfo
     google_timezone = google_time.tzinfo
-    logger.debug(f"Notion Timezone: {notion_timezone}, Google Calendar Timezone: {google_timezone}")
+    logger.debug(
+        f"Notion Timezone: {notion_timezone}, Google Calendar Timezone: {google_timezone}"
+    )
     if notion_timezone != google_timezone:
-        raise SyncAbortError(f"Timezones are different: Notion {notion_timezone} and Google Calendar {google_timezone}")
+        raise SyncAbortError(
+            f"Timezones are different: Notion {notion_timezone} and Google Calendar {google_timezone}"
+        )
 
 
 def get_current_time_in_iso_format():
@@ -57,7 +63,9 @@ def get_gcal_event_from_list(gcal_event_list, gcal_event_id):
         if gcal_event.get("id") == gcal_event_id:
             return gcal_event
 
-    logger.debug(f"Google Calendar event '{gcal_event_id}' not found in the provided list")
+    logger.debug(
+        f"Google Calendar event '{gcal_event_id}' not found in the provided list"
+    )
     return None
 
 
@@ -74,9 +82,7 @@ def _build_sync_error(
     error_message: str | None = None,
     error: str | None = None,
     notion_task_id: str | None = None,
-    notion_task_name: str | None = None,
     gcal_event_id: str | None = None,
-    gcal_event_title: str | None = None,
     gcal_event_start: str | None = None,
     retriable: bool | None = None,
     debug_detail: str | None = None,
@@ -88,9 +94,7 @@ def _build_sync_error(
         "error_message": message,
         "error": error,
         "notion_task_id": notion_task_id,
-        "notion_task_name": notion_task_name,
         "gcal_event_id": gcal_event_id,
-        "gcal_event_title": gcal_event_title,
         "gcal_event_start": gcal_event_start,
         "retriable": retriable,
     }
@@ -145,7 +149,9 @@ def synchronize_notion_and_google_calendar(
                 }
             # No Notion tasks found and no Google Calendar events found
             if task_count == 0 and event_count == 0:
-                logger.debug("No Notion tasks found and no Google Calendar events found.")
+                logger.debug(
+                    "No Notion tasks found and no Google Calendar events found."
+                )
                 return {
                     "statusCode": 200,
                     "body": {
@@ -180,10 +186,18 @@ def synchronize_notion_and_google_calendar(
                 if not notion_gcal_cal_name:
                     notion_gcal_cal_name = user_setting["gcal_default_name"]
                     notion_gcal_cal_id = user_setting["gcal_default_id"]
-                    logger.warning(f"Calendar name not found. Use the default calendar: {notion_gcal_cal_name}")
-                    logger.debug(f"Calendar id not found. Use the default calendar id: {notion_gcal_cal_id}")
-                    logger.info("Update Notion Task for default calendar id and calendar name")
-                    notion_service.update_notion_task_for_default_calendar(notion_task_page_id, notion_gcal_cal_name)
+                    logger.warning(
+                        f"Calendar name not found. Use the default calendar: {notion_gcal_cal_name}"
+                    )
+                    logger.debug(
+                        f"Calendar id not found. Use the default calendar id: {notion_gcal_cal_id}"
+                    )
+                    logger.info(
+                        "Update Notion Task for default calendar id and calendar name"
+                    )
+                    notion_service.update_notion_task_for_default_calendar(
+                        notion_task_page_id, notion_gcal_cal_name
+                    )
                 else:
                     notion_gcal_cal_id = gcal_name_dict.get(notion_gcal_cal_name)
                     if not notion_gcal_cal_id:
@@ -217,31 +231,53 @@ def synchronize_notion_and_google_calendar(
                 # Notion Task without Google Calendar Event ID - Create a new event in Google Calendar
                 if not notion_gcal_event_id and should_update_google_events:
                     if notion_deletion:
-                        logger.debug("Skipping Google Calendar create for task marked deleted.")
+                        logger.debug(
+                            "Skipping Google Calendar create for task marked deleted."
+                        )
                         continue
                     action = "create_gcal"
-                    logger.debug("Creating a new event in Google Calendar for a Notion task.")
-                    new_gcal_event_id = google_service.create_gcal_event(notion_task, notion_gcal_cal_id)
-                    notion_service.update_notion_task_for_new_gcal_event_id(notion_task_page_id, new_gcal_event_id)
+                    logger.debug(
+                        "Creating a new event in Google Calendar for a Notion task."
+                    )
+                    new_gcal_event_id = google_service.create_gcal_event(
+                        notion_task, notion_gcal_cal_id
+                    )
+                    notion_service.update_notion_task_for_new_gcal_event_id(
+                        notion_task_page_id, new_gcal_event_id
+                    )
                     continue
 
                 # Notion Task with deletion flag - Delete the event in Google Calendar
                 if notion_deletion and notion_gcal_event_id is not None:
                     action = "delete_gcal"
                     logger.debug("Deleting a Google Calendar event for a Notion task.")
-                    google_service.delete_gcal_event(notion_gcal_cal_id, notion_gcal_event_id)
+                    google_service.delete_gcal_event(
+                        notion_gcal_cal_id, notion_gcal_event_id
+                    )
                     notion_service.delete_notion_task(notion_task_page_id)
 
-                    duplicate_notion_task_list = notion_service.get_notion_task_by_gcal_event_id(notion_gcal_event_id)
+                    duplicate_notion_task_list = (
+                        notion_service.get_notion_task_by_gcal_event_id(
+                            notion_gcal_event_id
+                        )
+                    )
                     if duplicate_notion_task_list is not None:
                         for duplicate_notion_task in duplicate_notion_task_list:
                             duplicate_notion_task_page_id = duplicate_notion_task["id"]
-                            logger.debug(f"Duplicate Notion Task Page ID: {duplicate_notion_task_page_id}")
-                            notion_service.delete_notion_task(duplicate_notion_task_page_id)
+                            logger.debug(
+                                f"Duplicate Notion Task Page ID: {duplicate_notion_task_page_id}"
+                            )
+                            notion_service.delete_notion_task(
+                                duplicate_notion_task_page_id
+                            )
 
-                    deleted_gcal_event = get_gcal_event_from_list(gcal_event_list, notion_gcal_event_id)
+                    deleted_gcal_event = get_gcal_event_from_list(
+                        gcal_event_list, notion_gcal_event_id
+                    )
                     if deleted_gcal_event is not None:
-                        remove_gcal_event_from_list(gcal_event_list, deleted_gcal_event, notion_gcal_event_id)
+                        remove_gcal_event_from_list(
+                            gcal_event_list, deleted_gcal_event, notion_gcal_event_id
+                        )
                     continue
 
                 # Notion Task with Google Calendar Event ID - Check if the event is in Google Calendar
@@ -254,7 +290,10 @@ def synchronize_notion_and_google_calendar(
 
                     if notion_gcal_event_id == gcal_event_id:
                         if compare_time:
-                            if not notion_task_last_edited_time or not gcal_event_updated_time:
+                            if (
+                                not notion_task_last_edited_time
+                                or not gcal_event_updated_time
+                            ):
                                 logger.warning(
                                     "Missing last edited or updated time. Skipping sync for task_id=%s event_id=%s",
                                     notion_task_page_id,
@@ -262,7 +301,9 @@ def synchronize_notion_and_google_calendar(
                                 )
                                 continue
 
-                            compare_timezones(notion_task_last_edited_time, gcal_event_updated_time)
+                            compare_timezones(
+                                notion_task_last_edited_time, gcal_event_updated_time
+                            )
 
                             if (
                                 notion_gcal_sync_time
@@ -274,12 +315,15 @@ def synchronize_notion_and_google_calendar(
                                     notion_task_page_id,
                                     gcal_event_id,
                                 )
-                                remove_gcal_event_from_list(gcal_event_list, gcal_event, gcal_event_summary)
+                                remove_gcal_event_from_list(
+                                    gcal_event_list, gcal_event, gcal_event_summary
+                                )
                                 break
 
                         # Update Google Calendar if Notion is newer or force update
                         if should_update_google_events and (
-                            not compare_time or (notion_task_last_edited_time > gcal_event_updated_time)
+                            not compare_time
+                            or (notion_task_last_edited_time > gcal_event_updated_time)
                         ):
                             action = "update_gcal"
                             logger.debug(
@@ -287,7 +331,9 @@ def synchronize_notion_and_google_calendar(
                                 notion_task_page_id,
                                 gcal_event_id,
                             )
-                            logger.debug("Updating the Google Calendar event from Notion.")
+                            logger.debug(
+                                "Updating the Google Calendar event from Notion."
+                            )
                             if notion_gcal_cal_id == gcal_cal_id:
                                 google_service.update_gcal_event(
                                     notion_task,
@@ -310,7 +356,8 @@ def synchronize_notion_and_google_calendar(
                             )
                         # Update Notion if Google Calendar is newer or force update
                         elif should_update_notion_tasks and (
-                            not compare_time or (notion_task_last_edited_time < gcal_event_updated_time)
+                            not compare_time
+                            or (notion_task_last_edited_time < gcal_event_updated_time)
                         ):
                             action = "update_notion"
                             description = gcal_event.get("description") or ""
@@ -325,10 +372,10 @@ def synchronize_notion_and_google_calendar(
                                             "Syncing this event would corrupt data integrity."
                                         ),
                                         notion_task_id=notion_task_page_id,
-                                        notion_task_name=notion_task_name,
                                         gcal_event_id=gcal_event_id,
-                                        gcal_event_title=gcal_event_summary,
-                                        gcal_event_start=gcal_event.get("start", {}).get("dateTime")
+                                        gcal_event_start=gcal_event.get(
+                                            "start", {}
+                                        ).get("dateTime")
                                         or gcal_event.get("start", {}).get("date"),
                                         retriable=False,
                                     )
@@ -344,7 +391,9 @@ def synchronize_notion_and_google_calendar(
                                     notion_task_page_id,
                                     gcal_event_id,
                                 )
-                                logger.debug("Updating the Notion task from Google Calendar.")
+                                logger.debug(
+                                    "Updating the Notion task from Google Calendar."
+                                )
                                 notion_service.update_notion_task(
                                     notion_task_page_id,
                                     gcal_event,
@@ -352,9 +401,13 @@ def synchronize_notion_and_google_calendar(
                                     current_gcal_sync_time,
                                 )
                         else:
-                            logger.debug("Notion task and Google event are already in sync.")
+                            logger.debug(
+                                "Notion task and Google event are already in sync."
+                            )
 
-                        remove_gcal_event_from_list(gcal_event_list, gcal_event, gcal_event_summary)
+                        remove_gcal_event_from_list(
+                            gcal_event_list, gcal_event, gcal_event_summary
+                        )
                         break
 
             except SyncAbortError:
@@ -368,11 +421,12 @@ def synchronize_notion_and_google_calendar(
                         error=None,
                         debug_detail=build_debug_exception_detail(e),
                         notion_task_id=notion_task_page_id,
-                        notion_task_name=notion_task_name,
                         gcal_event_id=notion_gcal_event_id,
-                        gcal_event_title=(gcal_event_summary if "gcal_event_summary" in locals() else None),
                         gcal_event_start=(
-                            (gcal_event.get("start", {}).get("dateTime") or gcal_event.get("start", {}).get("date"))
+                            (
+                                gcal_event.get("start", {}).get("dateTime")
+                                or gcal_event.get("start", {}).get("date")
+                            )
                             if "gcal_event" in locals()
                             else None
                         ),
@@ -387,11 +441,14 @@ def synchronize_notion_and_google_calendar(
 
         # Create new tasks in Notion for the remaining Google Calendar events
         if len(gcal_event_list) > 0 and should_update_notion_tasks:
-            logger.debug(f"🟢Google Calendar: Creating new tasks in Notion for {len(gcal_event_list)} events")
+            logger.debug(
+                f"🟢Google Calendar: Creating new tasks in Notion for {len(gcal_event_list)} events"
+            )
             for gcal_event in gcal_event_list:
                 gcal_event_id = gcal_event.get("id")
                 logger.debug(
-                    f"Google Calendar: Creating a new task in Notion for event '{gcal_event.get('summary', '')}'"
+                    "Google Calendar: Creating a new task in Notion for event_id=%s",
+                    gcal_event_id,
                 )
                 try:
                     organizer_email = (gcal_event.get("organizer") or {}).get("email")
@@ -406,8 +463,9 @@ def synchronize_notion_and_google_calendar(
                                     "so it was not synced."
                                 ),
                                 gcal_event_id=gcal_event_id,
-                                gcal_event_title=gcal_event.get("summary", ""),
-                                gcal_event_start=gcal_event.get("start", {}).get("dateTime")
+                                gcal_event_start=gcal_event.get("start", {}).get(
+                                    "dateTime"
+                                )
                                 or gcal_event.get("start", {}).get("date"),
                                 retriable=False,
                             )
@@ -429,8 +487,9 @@ def synchronize_notion_and_google_calendar(
                                     "Syncing this event would corrupt data integrity."
                                 ),
                                 gcal_event_id=gcal_event_id,
-                                gcal_event_title=gcal_event.get("summary", ""),
-                                gcal_event_start=gcal_event.get("start", {}).get("dateTime")
+                                gcal_event_start=gcal_event.get("start", {}).get(
+                                    "dateTime"
+                                )
                                 or gcal_event.get("start", {}).get("date"),
                                 retriable=False,
                             )
@@ -450,13 +509,14 @@ def synchronize_notion_and_google_calendar(
                             error=None,
                             debug_detail=build_debug_exception_detail(e),
                             gcal_event_id=gcal_event_id,
-                            gcal_event_title=gcal_event.get("summary", ""),
                             gcal_event_start=gcal_event.get("start", {}).get("dateTime")
                             or gcal_event.get("start", {}).get("date"),
                             retriable=True,
                         )
                     )
-                    logger.exception("Error during create_notion for event_id=%s", gcal_event_id)
+                    logger.exception(
+                        "Error during create_notion for event_id=%s", gcal_event_id
+                    )
 
     except Exception as e:
         logger.exception("Error during synchronization")
@@ -479,7 +539,9 @@ def synchronize_notion_and_google_calendar(
     return {"statusCode": 200, "body": {"status": "sync_success", "message": message}}
 
 
-def force_update_notion_tasks_by_google_event_and_ignore_time(user_setting, notion_service, google_service):
+def force_update_notion_tasks_by_google_event_and_ignore_time(
+    user_setting, notion_service, google_service
+):
     # -ga
     # Only update notion tasks
     # Do not update google events (Keep the google events as it is)
@@ -494,7 +556,9 @@ def force_update_notion_tasks_by_google_event_and_ignore_time(user_setting, noti
     return result
 
 
-def force_update_google_event_by_notion_task_and_ignore_time(user_setting, notion_service, google_service):
+def force_update_google_event_by_notion_task_and_ignore_time(
+    user_setting, notion_service, google_service
+):
     # -na
     # Only update google events
     # Do not update notion tasks (Keep the notion tasks as it is)

--- a/src/utils/dynamodb_utils.py
+++ b/src/utils/dynamodb_utils.py
@@ -103,7 +103,9 @@ def get_google_token_by_uuid(uuid: str) -> str:
 
 
 # update item in google oauth token tables by uuid
-def update_google_token_by_uuid(uuid: str, access_token: str, refresh_token: str, expiry_date: str, updated_at: str):
+def update_google_token_by_uuid(
+    uuid: str, access_token: str, refresh_token: str, expiry_date: str, updated_at: str
+):
     google_tbl = _get_google_tables()
     encrypted_access_token = encrypt_token_if_plaintext(access_token)
     encrypted_refresh_token = encrypt_token_if_plaintext(refresh_token)

--- a/src/utils/dynamodb_utils.py
+++ b/src/utils/dynamodb_utils.py
@@ -103,9 +103,7 @@ def get_google_token_by_uuid(uuid: str) -> str:
 
 
 # update item in google oauth token tables by uuid
-def update_google_token_by_uuid(
-    uuid: str, access_token: str, refresh_token: str, expiry_date: str, updated_at: str
-):
+def update_google_token_by_uuid(uuid: str, access_token: str, refresh_token: str, expiry_date: str, updated_at: str):
     google_tbl = _get_google_tables()
     encrypted_access_token = encrypt_token_if_plaintext(access_token)
     encrypted_refresh_token = encrypt_token_if_plaintext(refresh_token)

--- a/src/utils/dynamodb_utils.py
+++ b/src/utils/dynamodb_utils.py
@@ -2,7 +2,7 @@ import os
 import time
 from datetime import datetime, timezone
 import boto3
-from utils.token_crypto import decrypt_token_if_encrypted, encrypt_token_if_plaintext
+from utils.token_crypto import encrypt_token_if_plaintext
 
 
 def _get_dynamodb():
@@ -89,8 +89,6 @@ def get_notion_token_by_uuid(uuid: str) -> str:
     item = response.get("Item")
     if not item:
         raise ValueError(f"No Notion token found for uuid: {uuid}")
-    if "accessToken" in item:
-        item["accessToken"] = decrypt_token_if_encrypted(item.get("accessToken"))
     return item
 
 
@@ -101,10 +99,6 @@ def get_google_token_by_uuid(uuid: str) -> str:
     item = response.get("Item")
     if not item:
         raise ValueError(f"No Google token found for uuid: {uuid}")
-    if "accessToken" in item:
-        item["accessToken"] = decrypt_token_if_encrypted(item.get("accessToken"))
-    if "refreshToken" in item:
-        item["refreshToken"] = decrypt_token_if_encrypted(item.get("refreshToken"))
     return item
 
 

--- a/src/utils/lambda_utils.py
+++ b/src/utils/lambda_utils.py
@@ -3,8 +3,10 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Optional, TypedDict
 
 MAX_SYNC_LOG_ERRORS = 3
-SYNC_LOG_CONTRACT_VERSION = "2026-05-23.sync-log.v1"
-SAFE_SYNC_FAILURE_MESSAGE = "Sync failed. See Lambda logs with aws_request_id for details."
+SYNC_LOG_CONTRACT_VERSION = "2026-05-31.sync-log.v2"
+SAFE_SYNC_FAILURE_MESSAGE = (
+    "Sync failed. See Lambda logs with aws_request_id for details."
+)
 
 # Sentinel used as the uuid field on SQS batch-aggregate summaries.
 # It is never a real user UUID and must never be written to DynamoDB.
@@ -16,8 +18,6 @@ class SyncErrorPayload(TypedDict):
     error_code: str
     error_message: str | None
     error: str | None
-    gcal_event_title: str | None
-    notion_task_name: str | None
     gcal_event_start: str | None
     gcal_event_id: str | None
     notion_task_id: str | None
@@ -31,8 +31,6 @@ def sanitize_sync_error(error: Any) -> SyncErrorPayload:
             "error_code": "unstructured_sync_error",
             "error_message": str(error),
             "error": str(error),
-            "gcal_event_title": None,
-            "notion_task_name": None,
             "gcal_event_start": None,
             "gcal_event_id": None,
             "notion_task_id": None,
@@ -52,8 +50,6 @@ def sanitize_sync_error(error: Any) -> SyncErrorPayload:
         "error_code": error.get("error_code") or "unknown_sync_error",
         "error_message": error_message,
         "error": raw_error,
-        "gcal_event_title": error.get("gcal_event_title"),
-        "notion_task_name": error.get("notion_task_name"),
         "gcal_event_start": error.get("gcal_event_start"),
         "gcal_event_id": error.get("gcal_event_id"),
         "notion_task_id": error.get("notion_task_id"),
@@ -68,7 +64,11 @@ def sanitize_sync_log_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     status_code = payload.get("statusCode")
     if isinstance(message, str):
         # Keep user-facing sync failures generic when upstream returned plaintext.
-        if status == "sync_error" and isinstance(status_code, int) and status_code >= 500:
+        if (
+            status == "sync_error"
+            and isinstance(status_code, int)
+            and status_code >= 500
+        ):
             sanitized_payload["message"] = {
                 "error_code": "sync_runtime_error",
                 "error_message": SAFE_SYNC_FAILURE_MESSAGE,
@@ -84,10 +84,14 @@ def sanitize_sync_log_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
 
     original_error_count = len(errors)
     sanitized_message = dict(message)
-    sanitized_message["errors"] = [sanitize_sync_error(err) for err in errors[:MAX_SYNC_LOG_ERRORS]]
+    sanitized_message["errors"] = [
+        sanitize_sync_error(err) for err in errors[:MAX_SYNC_LOG_ERRORS]
+    ]
     sanitized_message["error_count"] = original_error_count
     sanitized_message["errors_truncated"] = original_error_count > MAX_SYNC_LOG_ERRORS
-    sanitized_message["omitted_error_count"] = max(original_error_count - MAX_SYNC_LOG_ERRORS, 0)
+    sanitized_message["omitted_error_count"] = max(
+        original_error_count - MAX_SYNC_LOG_ERRORS, 0
+    )
     sanitized_payload["message"] = sanitized_message
     return sanitized_payload
 
@@ -120,7 +124,9 @@ def process_and_log_sync_result(
             "lambda_name": getattr(context, "function_name", "unknown"),
             "aws_request_id": getattr(context, "aws_request_id", "unknown"),
             "log_level": logger_obj.level,
-            "duration_ms": int((datetime.now(timezone.utc) - lambda_start_time).total_seconds() * 1000),
+            "duration_ms": int(
+                (datetime.now(timezone.utc) - lambda_start_time).total_seconds() * 1000
+            ),
         }
         if extra:
             payload.update(extra)
@@ -136,7 +142,9 @@ def process_and_log_sync_result(
             "lambda_name": getattr(context, "function_name", "unknown"),
             "aws_request_id": getattr(context, "aws_request_id", "unknown"),
             "log_level": logger_obj.level,
-            "duration_ms": int((datetime.now(timezone.utc) - lambda_start_time).total_seconds() * 1000),
+            "duration_ms": int(
+                (datetime.now(timezone.utc) - lambda_start_time).total_seconds() * 1000
+            ),
         }
     # Persist summary to DynamoDB; don't fail the handler on logging errors
     try:
@@ -150,13 +158,20 @@ def process_and_log_sync_result(
 
 
 def process_sqs_records(
-    logger_obj, event: Dict[str, Any], context: Any, run_sync, lambda_start_time: datetime
+    logger_obj,
+    event: Dict[str, Any],
+    context: Any,
+    run_sync,
+    lambda_start_time: datetime,
 ) -> Dict[str, Any]:
     """
     SQS batch processing: handle each record, summarize, and log
     """
     sqs_batch_results = []
-    logger_obj.debug(f"Processing SQS event with {len(event.get('Records', []))} records")
+    batch_item_failures = []
+    logger_obj.debug(
+        f"Processing SQS event with {len(event.get('Records', []))} records"
+    )
 
     # Process each SQS record
     for record in event["Records"]:
@@ -167,17 +182,21 @@ def process_sqs_records(
             body = json.loads(record.get("body", "{}"))
             provided_uuid = body.get("uuid")
             sync_result = run_sync(provided_uuid)
-            sqs_batch_results.append(
-                process_and_log_sync_result(
-                    logger_obj=logger_obj,
-                    sync_result=sync_result,
-                    context=context,
-                    uuid=provided_uuid,
-                    lambda_start_time=lambda_start_time,
-                    trigger_name="sqs",
-                    extra={"job_id": job_id},
-                )
+            processed_result = process_and_log_sync_result(
+                logger_obj=logger_obj,
+                sync_result=sync_result,
+                context=context,
+                uuid=provided_uuid,
+                lambda_start_time=lambda_start_time,
+                trigger_name="sqs",
+                extra={"job_id": job_id},
             )
+            sqs_batch_results.append(processed_result)
+            if (
+                isinstance(processed_result.get("statusCode"), int)
+                and processed_result.get("statusCode", 500) >= 500
+            ):
+                batch_item_failures.append({"itemIdentifier": job_id})
         except Exception:
             logger_obj.exception("Error processing SQS record")
             sqs_batch_results.append(
@@ -188,10 +207,13 @@ def process_sqs_records(
                     "error": "record processing failed",
                 }
             )
+            batch_item_failures.append({"itemIdentifier": job_id})
 
     # Summarize results for batch logging
     success_count = sum(
-        1 for s in sqs_batch_results if isinstance(s.get("statusCode"), int) and s.get("statusCode", 500) < 400
+        1
+        for s in sqs_batch_results
+        if isinstance(s.get("statusCode"), int) and s.get("statusCode", 500) < 400
     )
     failure_count = len(sqs_batch_results) - success_count
 
@@ -202,18 +224,21 @@ def process_sqs_records(
         for s in sqs_batch_results
         if isinstance(s.get("statusCode"), int) and s.get("statusCode", 500) < 400
     ]
-    failure_uuids = [s.get("uuid") for s in sqs_batch_results if s.get("uuid") not in success_uuids]
+    failure_uuids = [
+        s.get("uuid") for s in sqs_batch_results if s.get("uuid") not in success_uuids
+    ]
     batch_sync_result = {
         # Provide an explicit statusCode for downstream handler uniformity
         "statusCode": 200,
         "body": {
             "status": "batch_processed",
             "message": (
-                f"Processed {len(sqs_batch_results)} records: " f"{success_count} succeeded, {failure_count} failed."
+                f"Processed {len(sqs_batch_results)} records: "
+                f"{success_count} succeeded, {failure_count} failed."
             ),
         },
     }
-    return process_and_log_sync_result(
+    batch_summary = process_and_log_sync_result(
         logger_obj=logger_obj,
         sync_result=batch_sync_result,
         context=context,
@@ -227,13 +252,21 @@ def process_sqs_records(
             "record_summaries": sqs_batch_results,  # concise per-record summary list
             "success_uuids": success_uuids,
             "failure_uuids": failure_uuids,
-            "record_uuids": [u for u in success_uuids + failure_uuids if u],  # all uuids in order
+            "record_uuids": [
+                u for u in success_uuids + failure_uuids if u
+            ],  # all uuids in order
         },
     )
+    batch_summary["batchItemFailures"] = batch_item_failures
+    return batch_summary
 
 
 def process_eventbridge_event(
-    logger_obj, event: Dict[str, Any], context: Any, run_sync, lambda_start_time: datetime
+    logger_obj,
+    event: Dict[str, Any],
+    context: Any,
+    run_sync,
+    lambda_start_time: datetime,
 ) -> Dict[str, Any]:
     """
     Process EventBridge event.
@@ -254,7 +287,12 @@ def process_eventbridge_event(
             uuid=provided_uuid,
             lambda_start_time=lambda_start_time,
             trigger_name="eventbridge",
-            extra={"event_id": event_id, "detail_type": detail_type, "source": event_source, "event_time": event_time},
+            extra={
+                "event_id": event_id,
+                "detail_type": detail_type,
+                "source": event_source,
+                "event_time": event_time,
+            },
         )
         return result
     except Exception:

--- a/src/utils/lambda_utils.py
+++ b/src/utils/lambda_utils.py
@@ -4,9 +4,7 @@ from typing import Any, Dict, Optional, TypedDict
 
 MAX_SYNC_LOG_ERRORS = 3
 SYNC_LOG_CONTRACT_VERSION = "2026-05-31.sync-log.v2"
-SAFE_SYNC_FAILURE_MESSAGE = (
-    "Sync failed. See Lambda logs with aws_request_id for details."
-)
+SAFE_SYNC_FAILURE_MESSAGE = "Sync failed. See Lambda logs with aws_request_id for details."
 
 # Sentinel used as the uuid field on SQS batch-aggregate summaries.
 # It is never a real user UUID and must never be written to DynamoDB.
@@ -64,11 +62,7 @@ def sanitize_sync_log_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     status_code = payload.get("statusCode")
     if isinstance(message, str):
         # Keep user-facing sync failures generic when upstream returned plaintext.
-        if (
-            status == "sync_error"
-            and isinstance(status_code, int)
-            and status_code >= 500
-        ):
+        if status == "sync_error" and isinstance(status_code, int) and status_code >= 500:
             sanitized_payload["message"] = {
                 "error_code": "sync_runtime_error",
                 "error_message": SAFE_SYNC_FAILURE_MESSAGE,
@@ -84,14 +78,10 @@ def sanitize_sync_log_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
 
     original_error_count = len(errors)
     sanitized_message = dict(message)
-    sanitized_message["errors"] = [
-        sanitize_sync_error(err) for err in errors[:MAX_SYNC_LOG_ERRORS]
-    ]
+    sanitized_message["errors"] = [sanitize_sync_error(err) for err in errors[:MAX_SYNC_LOG_ERRORS]]
     sanitized_message["error_count"] = original_error_count
     sanitized_message["errors_truncated"] = original_error_count > MAX_SYNC_LOG_ERRORS
-    sanitized_message["omitted_error_count"] = max(
-        original_error_count - MAX_SYNC_LOG_ERRORS, 0
-    )
+    sanitized_message["omitted_error_count"] = max(original_error_count - MAX_SYNC_LOG_ERRORS, 0)
     sanitized_payload["message"] = sanitized_message
     return sanitized_payload
 
@@ -124,9 +114,7 @@ def process_and_log_sync_result(
             "lambda_name": getattr(context, "function_name", "unknown"),
             "aws_request_id": getattr(context, "aws_request_id", "unknown"),
             "log_level": logger_obj.level,
-            "duration_ms": int(
-                (datetime.now(timezone.utc) - lambda_start_time).total_seconds() * 1000
-            ),
+            "duration_ms": int((datetime.now(timezone.utc) - lambda_start_time).total_seconds() * 1000),
         }
         if extra:
             payload.update(extra)
@@ -142,9 +130,7 @@ def process_and_log_sync_result(
             "lambda_name": getattr(context, "function_name", "unknown"),
             "aws_request_id": getattr(context, "aws_request_id", "unknown"),
             "log_level": logger_obj.level,
-            "duration_ms": int(
-                (datetime.now(timezone.utc) - lambda_start_time).total_seconds() * 1000
-            ),
+            "duration_ms": int((datetime.now(timezone.utc) - lambda_start_time).total_seconds() * 1000),
         }
     # Persist summary to DynamoDB; don't fail the handler on logging errors
     try:
@@ -169,9 +155,7 @@ def process_sqs_records(
     """
     sqs_batch_results = []
     batch_item_failures = []
-    logger_obj.debug(
-        f"Processing SQS event with {len(event.get('Records', []))} records"
-    )
+    logger_obj.debug(f"Processing SQS event with {len(event.get('Records', []))} records")
 
     # Process each SQS record
     for record in event["Records"]:
@@ -192,10 +176,7 @@ def process_sqs_records(
                 extra={"job_id": job_id},
             )
             sqs_batch_results.append(processed_result)
-            if (
-                isinstance(processed_result.get("statusCode"), int)
-                and processed_result.get("statusCode", 500) >= 500
-            ):
+            if isinstance(processed_result.get("statusCode"), int) and processed_result.get("statusCode", 500) >= 500:
                 batch_item_failures.append({"itemIdentifier": job_id})
         except Exception:
             logger_obj.exception("Error processing SQS record")
@@ -211,9 +192,7 @@ def process_sqs_records(
 
     # Summarize results for batch logging
     success_count = sum(
-        1
-        for s in sqs_batch_results
-        if isinstance(s.get("statusCode"), int) and s.get("statusCode", 500) < 400
+        1 for s in sqs_batch_results if isinstance(s.get("statusCode"), int) and s.get("statusCode", 500) < 400
     )
     failure_count = len(sqs_batch_results) - success_count
 
@@ -224,17 +203,14 @@ def process_sqs_records(
         for s in sqs_batch_results
         if isinstance(s.get("statusCode"), int) and s.get("statusCode", 500) < 400
     ]
-    failure_uuids = [
-        s.get("uuid") for s in sqs_batch_results if s.get("uuid") not in success_uuids
-    ]
+    failure_uuids = [s.get("uuid") for s in sqs_batch_results if s.get("uuid") not in success_uuids]
     batch_sync_result = {
         # Provide an explicit statusCode for downstream handler uniformity
         "statusCode": 200,
         "body": {
             "status": "batch_processed",
             "message": (
-                f"Processed {len(sqs_batch_results)} records: "
-                f"{success_count} succeeded, {failure_count} failed."
+                f"Processed {len(sqs_batch_results)} records: " f"{success_count} succeeded, {failure_count} failed."
             ),
         },
     }
@@ -252,9 +228,7 @@ def process_sqs_records(
             "record_summaries": sqs_batch_results,  # concise per-record summary list
             "success_uuids": success_uuids,
             "failure_uuids": failure_uuids,
-            "record_uuids": [
-                u for u in success_uuids + failure_uuids if u
-            ],  # all uuids in order
+            "record_uuids": [u for u in success_uuids + failure_uuids if u],  # all uuids in order
         },
     )
     batch_summary["batchItemFailures"] = batch_item_failures

--- a/test/test_dynamodb_utils.py
+++ b/test/test_dynamodb_utils.py
@@ -6,7 +6,10 @@ from unittest.mock import MagicMock, patch
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
 sys.path.insert(0, str(SRC_ROOT))
 
-from utils.dynamodb_utils import get_google_token_by_uuid, update_google_token_by_uuid  # noqa: E402
+from utils.dynamodb_utils import (
+    get_google_token_by_uuid,
+    update_google_token_by_uuid,
+)  # noqa: E402
 from utils.token_crypto import TokenCryptoError  # noqa: E402
 
 
@@ -46,7 +49,9 @@ class DynamoDbGoogleTokenTests(unittest.TestCase):
                 "utils.dynamodb_utils.encrypt_token_if_plaintext",
                 side_effect=["enc:v1:access", "enc:v1:refresh"],
             ) as mock_encrypt:
-                update_google_token_by_uuid("u-1", "plain-access", "plain-refresh", "111", "222")
+                update_google_token_by_uuid(
+                    "u-1", "plain-access", "plain-refresh", "111", "222"
+                )
 
         self.assertEqual(mock_encrypt.call_args_list[0].args[0], "plain-access")
         self.assertEqual(mock_encrypt.call_args_list[1].args[0], "plain-refresh")
@@ -63,7 +68,10 @@ class DynamoDbGoogleTokenTests(unittest.TestCase):
         access = "enc:v1:access"
         refresh = "enc:v1:refresh"
         with patch("utils.dynamodb_utils._get_google_tables", return_value=table):
-            with patch("utils.dynamodb_utils.encrypt_token_if_plaintext", side_effect=[access, refresh]):
+            with patch(
+                "utils.dynamodb_utils.encrypt_token_if_plaintext",
+                side_effect=[access, refresh],
+            ):
                 update_google_token_by_uuid("u-1", access, refresh, "111", "222")
 
         values = table.update_item.call_args.kwargs["ExpressionAttributeValues"]
@@ -78,7 +86,9 @@ class DynamoDbGoogleTokenTests(unittest.TestCase):
                 side_effect=TokenCryptoError("Malformed encrypted token payload."),
             ):
                 with self.assertRaises(TokenCryptoError):
-                    update_google_token_by_uuid("u-1", "enc:v1:broken", "plain-refresh", "111", "222")
+                    update_google_token_by_uuid(
+                        "u-1", "enc:v1:broken", "plain-refresh", "111", "222"
+                    )
         table.update_item.assert_not_called()
 
 

--- a/test/test_dynamodb_utils.py
+++ b/test/test_dynamodb_utils.py
@@ -6,10 +6,10 @@ from unittest.mock import MagicMock, patch
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
 sys.path.insert(0, str(SRC_ROOT))
 
-from utils.dynamodb_utils import (
+from utils.dynamodb_utils import (  # noqa: E402
     get_google_token_by_uuid,
     update_google_token_by_uuid,
-)  # noqa: E402
+)
 from utils.token_crypto import TokenCryptoError  # noqa: E402
 
 

--- a/test/test_dynamodb_utils.py
+++ b/test/test_dynamodb_utils.py
@@ -11,7 +11,7 @@ from utils.token_crypto import TokenCryptoError  # noqa: E402
 
 
 class DynamoDbGoogleTokenTests(unittest.TestCase):
-    def test_get_google_token_decrypts_encrypted_fields(self):
+    def test_get_google_token_returns_raw_stored_fields(self):
         table = MagicMock()
         table.get_item.return_value = {
             "Item": {
@@ -21,14 +21,11 @@ class DynamoDbGoogleTokenTests(unittest.TestCase):
             }
         }
         with patch("utils.dynamodb_utils._get_google_tables", return_value=table):
-            with patch(
-                "utils.dynamodb_utils.decrypt_token_if_encrypted", side_effect=["plain-access", "plain-refresh"]
-            ):
-                item = get_google_token_by_uuid("u-1")
-        self.assertEqual(item["accessToken"], "plain-access")
-        self.assertEqual(item["refreshToken"], "plain-refresh")
+            item = get_google_token_by_uuid("u-1")
+        self.assertEqual(item["accessToken"], "enc:v1:encrypted-access")
+        self.assertEqual(item["refreshToken"], "enc:v1:encrypted-refresh")
 
-    def test_get_google_token_keeps_legacy_plaintext_fields(self):
+    def test_get_google_token_returns_plaintext_fields_unchanged(self):
         table = MagicMock()
         table.get_item.return_value = {
             "Item": {

--- a/test/test_gcal_token.py
+++ b/test/test_gcal_token.py
@@ -8,12 +8,19 @@ from unittest.mock import MagicMock, patch
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
 sys.path.insert(0, str(SRC_ROOT))
 
-from gcal.gcal_token import GoogleToken, SettingError, _DEFAULT_SCOPES, _DEFAULT_TOKEN_URI  # noqa: E402
+from gcal.gcal_token import (
+    GoogleToken,
+    SettingError,
+    _DEFAULT_SCOPES,
+    _DEFAULT_TOKEN_URI,
+)  # noqa: E402
 from google.oauth2.credentials import Credentials  # noqa: E402
 from utils.token_crypto import TokenCryptoError, encrypt_token  # noqa: E402
 
 # A far-future expiry in ms — prevents credentials.expired from being True in cloud tests
-_FUTURE_EXPIRY_MS = str(int(datetime(2030, 1, 1, tzinfo=timezone.utc).timestamp() * 1000))
+_FUTURE_EXPIRY_MS = str(
+    int(datetime(2030, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+)
 
 _CLOUD_DYNAMO_RESPONSE = {
     "accessToken": "enc:v1:encrypted-cloud-access-token",
@@ -30,7 +37,9 @@ _BASE_LOCAL_ENV = {
     "GOOGLE_CLIENT_SECRET": "test-client-secret",
     "GOOGLE_REFRESH_TOKEN": "test-refresh-token",
 }
-_TOKEN_ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+_TOKEN_ENCRYPTION_KEY = (
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+)
 
 
 def _make_logger():
@@ -80,7 +89,10 @@ class TestGoogleTokenLocalModeCredentialConstruction(unittest.TestCase):
 
     def test_encrypted_local_refresh_token_calls_decrypt_token(self):
         encrypted_token = "enc:v1:encrypted-refresh-token"
-        with patch("gcal.gcal_token.decrypt_token_if_encrypted", return_value="plain-refresh-token") as mock_decrypt:
+        with patch(
+            "gcal.gcal_token.decrypt_token_if_encrypted",
+            return_value="plain-refresh-token",
+        ) as mock_decrypt:
             creds = self._load(_local_env(GOOGLE_REFRESH_TOKEN=encrypted_token))
         mock_decrypt.assert_called_once_with(encrypted_token)
         self.assertEqual(creds.refresh_token, "plain-refresh-token")
@@ -93,7 +105,9 @@ class TestGoogleTokenLocalModeCredentialConstruction(unittest.TestCase):
         ):
             with self.assertRaises(SettingError) as ctx:
                 self._load(_local_env(GOOGLE_REFRESH_TOKEN=encrypted_token))
-        self.assertIn("Failed to decrypt encrypted Google OAuth token", str(ctx.exception))
+        self.assertIn(
+            "Failed to decrypt encrypted Google OAuth token", str(ctx.exception)
+        )
         self.assertIn("TOKEN_ENCRYPTION_KEY", str(ctx.exception))
 
     def test_token_is_none_before_refresh(self):
@@ -183,7 +197,9 @@ class TestGoogleTokenLocalModeActivation(unittest.TestCase):
         env = _local_env()
         with patch.dict(os.environ, env, clear=True):
             with patch("google.oauth2.credentials.Credentials.refresh"):
-                with patch("utils.dynamodb_utils.get_google_token_by_uuid") as mock_loader:
+                with patch(
+                    "utils.dynamodb_utils.get_google_token_by_uuid"
+                ) as mock_loader:
                     GoogleToken({"mode": "local"}, _make_logger())
                     mock_loader.assert_not_called()
 
@@ -191,7 +207,9 @@ class TestGoogleTokenLocalModeActivation(unittest.TestCase):
         env = _local_env()
         with patch.dict(os.environ, env, clear=True):
             with patch("google.oauth2.credentials.Credentials.refresh"):
-                with patch("utils.dynamodb_utils.update_google_token_by_uuid") as mock_updater:
+                with patch(
+                    "utils.dynamodb_utils.update_google_token_by_uuid"
+                ) as mock_updater:
                     GoogleToken({"mode": "local"}, _make_logger())
                     mock_updater.assert_not_called()
 
@@ -220,30 +238,55 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
         raise AssertionError(f"Unexpected token payload: {value}")
 
     def test_cloud_loads_token_from_dynamodb(self):
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE) as mock_loader:
-            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret") as mock_ssm:
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid",
+            return_value=_CLOUD_DYNAMO_RESPONSE,
+        ) as mock_loader:
+            with patch(
+                "gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt
+            ):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ) as mock_ssm:
                     with patch.dict(os.environ, _CLOUD_ENV):
                         gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
                     mock_loader.assert_called_once_with("my-uuid")
-                    mock_ssm.assert_called_once_with("/dev/notica/google_calendar_client_secret")
+                    mock_ssm.assert_called_once_with(
+                        "/dev/notica/google_calendar_client_secret"
+                    )
                     self.assertEqual(gt.credentials.token, "plain-cloud-access-token")
-                    self.assertEqual(gt.credentials.refresh_token, "plain-cloud-refresh-token")
+                    self.assertEqual(
+                        gt.credentials.refresh_token, "plain-cloud-refresh-token"
+                    )
 
     def test_cloud_mode_requires_client_secret_ssm_path(self):
         env = dict(_CLOUD_ENV)
         env.pop("GOOGLE_CALENDAR_CLIENT_SECRET_SSM_PATH")
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid",
+            return_value=_CLOUD_DYNAMO_RESPONSE,
+        ):
+            with patch(
+                "gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt
+            ):
                 with patch.dict(os.environ, env, clear=True):
                     with self.assertRaises(SettingError) as ctx:
                         GoogleToken(self._cloud_config(), _make_logger())
         self.assertIn("GOOGLE_CALENDAR_CLIENT_SECRET_SSM_PATH", str(ctx.exception))
 
     def test_cloud_mode_fetches_client_secret_from_ssm(self):
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret") as mock_ssm:
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid",
+            return_value=_CLOUD_DYNAMO_RESPONSE,
+        ):
+            with patch(
+                "gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt
+            ):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ) as mock_ssm:
                     with patch.dict(os.environ, _CLOUD_ENV, clear=True):
                         gt = GoogleToken(self._cloud_config(), _make_logger())
         mock_ssm.assert_called_once_with("/dev/notica/google_calendar_client_secret")
@@ -254,9 +297,16 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             **_CLOUD_ENV,
             "GOOGLE_CALENDAR_CLIENT_SECRET": "plaintext-secret-should-not-be-read",
         }
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="ssm-secret-value"):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid",
+            return_value=_CLOUD_DYNAMO_RESPONSE,
+        ):
+            with patch(
+                "gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt
+            ):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter", return_value="ssm-secret-value"
+                ):
                     with patch.dict(os.environ, env, clear=True):
                         gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
         self.assertEqual(gt.credentials.client_secret, "ssm-secret-value")
@@ -266,11 +316,17 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             **_CLOUD_DYNAMO_RESPONSE,
             "refreshToken": "enc:v1:encrypted-cloud-refresh-token",
         }
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=response):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid", return_value=response
+        ):
             with patch(
-                "gcal.gcal_token.decrypt_token", return_value="plain-cloud-refresh-token"
+                "gcal.gcal_token.decrypt_token",
+                return_value="plain-cloud-refresh-token",
             ) as mock_decrypt:
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ):
                     with patch.dict(os.environ, _CLOUD_ENV):
                         gt = GoogleToken(self._cloud_config(), _make_logger())
         mock_decrypt.assert_any_call("enc:v1:encrypted-cloud-refresh-token")
@@ -281,20 +337,33 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             **_CLOUD_DYNAMO_RESPONSE,
             "accessToken": "enc:v1:encrypted-cloud-access-token",
         }
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=response):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid", return_value=response
+        ):
             with patch(
                 "gcal.gcal_token.decrypt_token", return_value="plain-cloud-access-token"
             ) as mock_decrypt:
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ):
                     with patch.dict(os.environ, _CLOUD_ENV):
                         gt = GoogleToken(self._cloud_config(), _make_logger())
         mock_decrypt.assert_any_call("enc:v1:encrypted-cloud-access-token")
         self.assertEqual(gt.credentials.token, "plain-cloud-access-token")
 
     def test_cloud_save_credentials_calls_dynamodb_updater(self):
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid",
+            return_value=_CLOUD_DYNAMO_RESPONSE,
+        ):
+            with patch(
+                "gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt
+            ):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ):
                     with patch.dict(os.environ, _CLOUD_ENV):
                         gt = GoogleToken(self._cloud_config(), _make_logger())
         mock_creds = MagicMock()
@@ -310,16 +379,29 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
                 },
                 clear=True,
             ):
-                with patch("utils.token_crypto.get_ssm_parameter", return_value=_TOKEN_ENCRYPTION_KEY):
+                with patch(
+                    "utils.token_crypto.get_ssm_parameter",
+                    return_value=_TOKEN_ENCRYPTION_KEY,
+                ):
                     gt._save_credentials(mock_creds)
             mock_updater.assert_called_once()
 
     def test_cloud_save_credentials_writes_encrypted_tokens(self):
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid",
+            return_value=_CLOUD_DYNAMO_RESPONSE,
+        ):
+            with patch(
+                "gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt
+            ):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ):
                     with patch.dict(os.environ, _CLOUD_ENV):
-                        gt = GoogleToken(self._cloud_config("uuid-encrypted-save"), _make_logger())
+                        gt = GoogleToken(
+                            self._cloud_config("uuid-encrypted-save"), _make_logger()
+                        )
         mock_creds = MagicMock()
         mock_creds.token = "new-access-token"
         mock_creds.refresh_token = "new-refresh-token"
@@ -334,7 +416,10 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
                 },
                 clear=True,
             ):
-                with patch("utils.token_crypto.get_ssm_parameter", return_value=_TOKEN_ENCRYPTION_KEY):
+                with patch(
+                    "utils.token_crypto.get_ssm_parameter",
+                    return_value=_TOKEN_ENCRYPTION_KEY,
+                ):
                     gt._save_credentials(mock_creds)
 
         _, saved_access_token, saved_refresh_token, _, _ = mock_updater.call_args[0]
@@ -342,9 +427,17 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
         self.assertEqual(saved_refresh_token, "new-refresh-token")
 
     def test_cloud_save_credentials_does_not_encrypt_in_gcal_token_layer(self):
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid",
+            return_value=_CLOUD_DYNAMO_RESPONSE,
+        ):
+            with patch(
+                "gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt
+            ):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ):
                     with patch.dict(os.environ, _CLOUD_ENV):
                         gt = GoogleToken(self._cloud_config(), _make_logger())
         mock_creds = MagicMock()
@@ -361,7 +454,9 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
         expired_response = {
             "accessToken": None,
             "refreshToken": None,
-            "expiryDate": str(int(datetime(2000, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)),
+            "expiryDate": str(
+                int(datetime(2000, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+            ),
         }
 
         def refresh_credentials(credentials, request):  # noqa: ARG001
@@ -369,7 +464,9 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             credentials._refresh_token = "refreshed-refresh-token"
             credentials.expiry = datetime(2030, 1, 1, tzinfo=timezone.utc)
 
-        with patch.dict(os.environ, {"TOKEN_ENCRYPTION_KEY": _TOKEN_ENCRYPTION_KEY}, clear=True):
+        with patch.dict(
+            os.environ, {"TOKEN_ENCRYPTION_KEY": _TOKEN_ENCRYPTION_KEY}, clear=True
+        ):
             expired_response["accessToken"] = encrypt_token("old-access-token")
             expired_response["refreshToken"] = encrypt_token("old-refresh-token")
 
@@ -383,11 +480,25 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             clear=True,
         ):
 
-            with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=expired_response):
-                with patch("utils.dynamodb_utils.update_google_token_by_uuid") as mock_updater:
-                    with patch("google.oauth2.credentials.Credentials.refresh", new=refresh_credentials):
-                        with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
-                            with patch("utils.token_crypto.get_ssm_parameter", return_value=_TOKEN_ENCRYPTION_KEY):
+            with patch(
+                "utils.dynamodb_utils.get_google_token_by_uuid",
+                return_value=expired_response,
+            ):
+                with patch(
+                    "utils.dynamodb_utils.update_google_token_by_uuid"
+                ) as mock_updater:
+                    with patch(
+                        "google.oauth2.credentials.Credentials.refresh",
+                        new=refresh_credentials,
+                    ):
+                        with patch(
+                            "gcal.gcal_token.get_ssm_parameter",
+                            return_value="gcal-client-secret",
+                        ):
+                            with patch(
+                                "utils.token_crypto.get_ssm_parameter",
+                                return_value=_TOKEN_ENCRYPTION_KEY,
+                            ):
                                 gt = GoogleToken(self._cloud_config(), _make_logger())
 
         self.assertEqual(gt.credentials.token, "refreshed-access-token")
@@ -400,9 +511,17 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
         response = {
             **_CLOUD_DYNAMO_RESPONSE,
         }
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=response):
-            with patch("gcal.gcal_token.decrypt_token", side_effect=["plain-access", "plain-refresh"]):
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid", return_value=response
+        ):
+            with patch(
+                "gcal.gcal_token.decrypt_token",
+                side_effect=["plain-access", "plain-refresh"],
+            ):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ):
                     with patch.dict(os.environ, _CLOUD_ENV, clear=True):
                         gt = GoogleToken(self._cloud_config(), _make_logger())
 
@@ -417,12 +536,17 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             "accessToken": "enc:v1:encrypted-cloud-access-token",
             "refreshToken": "enc:v1:encrypted-cloud-refresh-token",
         }
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=response):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid", return_value=response
+        ):
             with patch(
                 "gcal.gcal_token.decrypt_token",
                 side_effect=["enc:v1:still-encrypted", "plain-refresh"],
             ):
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ):
                     with patch.dict(os.environ, _CLOUD_ENV, clear=True):
                         with self.assertRaises(SettingError) as ctx:
                             GoogleToken(self._cloud_config(), _make_logger())
@@ -434,14 +558,19 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             "accessToken": "plain-cloud-access-token",
             "refreshToken": "enc:v1:encrypted-cloud-refresh-token",
         }
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=response):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid", return_value=response
+        ):
             with patch(
                 "gcal.gcal_token.decrypt_token",
                 side_effect=TokenCryptoError(
                     "Token is not encrypted (expected 'enc:v1:' prefix). All tokens in the database must be encrypted."
                 ),
             ):
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ):
                     with patch.dict(os.environ, _CLOUD_ENV, clear=True):
                         with self.assertRaises(SettingError) as ctx:
                             GoogleToken(self._cloud_config(), _make_logger())
@@ -452,7 +581,9 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             **_CLOUD_DYNAMO_RESPONSE,
             "refreshToken": "plain-cloud-refresh-token",
         }
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=response):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid", return_value=response
+        ):
             with patch(
                 "gcal.gcal_token.decrypt_token",
                 side_effect=[
@@ -462,16 +593,27 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
                     ),
                 ],
             ):
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ):
                     with patch.dict(os.environ, _CLOUD_ENV, clear=True):
                         with self.assertRaises(SettingError) as ctx:
                             GoogleToken(self._cloud_config(), _make_logger())
         self.assertIn("Token is not encrypted", str(ctx.exception))
 
     def test_cloud_refresh_preserves_existing_refresh_token_when_omitted(self):
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid",
+            return_value=_CLOUD_DYNAMO_RESPONSE,
+        ):
+            with patch(
+                "gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt
+            ):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ):
                     with patch.dict(os.environ, _CLOUD_ENV, clear=True):
                         gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
 
@@ -482,17 +624,30 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             credentials._refresh_token = None
             credentials.expiry = datetime(2030, 1, 1, tzinfo=timezone.utc)
 
-        with patch("google.oauth2.credentials.Credentials.refresh", new=refresh_without_new_refresh_token):
-            with patch("utils.dynamodb_utils.update_google_token_by_uuid") as mock_updater:
+        with patch(
+            "google.oauth2.credentials.Credentials.refresh",
+            new=refresh_without_new_refresh_token,
+        ):
+            with patch(
+                "utils.dynamodb_utils.update_google_token_by_uuid"
+            ) as mock_updater:
                 gt._refresh_tokens(gt.credentials)
 
         _, _, saved_refresh_token, _, _ = mock_updater.call_args[0]
         self.assertEqual(saved_refresh_token, original_refresh)
 
     def test_cloud_save_credentials_sets_updated_at_to_now_not_expiry(self):
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
-                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid",
+            return_value=_CLOUD_DYNAMO_RESPONSE,
+        ):
+            with patch(
+                "gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt
+            ):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ):
                     with patch.dict(os.environ, _CLOUD_ENV, clear=True):
                         gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
 
@@ -503,17 +658,30 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
 
         with patch("utils.dynamodb_utils.update_google_token_by_uuid") as mock_updater:
             with patch("gcal.gcal_token.datetime") as mock_datetime:
-                mock_datetime.now.return_value = datetime(2026, 1, 2, tzinfo=timezone.utc)
+                mock_datetime.now.return_value = datetime(
+                    2026, 1, 2, tzinfo=timezone.utc
+                )
                 gt._save_credentials(mock_creds)
 
         _, _, _, expiry_date, updated_at = mock_updater.call_args[0]
-        self.assertEqual(expiry_date, str(int(datetime(2030, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)))
-        self.assertEqual(updated_at, str(int(datetime(2026, 1, 2, tzinfo=timezone.utc).timestamp() * 1000)))
+        self.assertEqual(
+            expiry_date,
+            str(int(datetime(2030, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)),
+        )
+        self.assertEqual(
+            updated_at,
+            str(int(datetime(2026, 1, 2, tzinfo=timezone.utc).timestamp() * 1000)),
+        )
         self.assertNotEqual(updated_at, expiry_date)
 
     def test_cloud_dynamodb_error_raises_setting_error(self):
-        with patch("utils.dynamodb_utils.get_google_token_by_uuid", side_effect=RuntimeError("DDB down")):
-            with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid",
+            side_effect=RuntimeError("DDB down"),
+        ):
+            with patch(
+                "gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"
+            ):
                 with patch.dict(os.environ, _CLOUD_ENV):
                     with self.assertRaises(SettingError) as ctx:
                         GoogleToken(self._cloud_config(), _make_logger())

--- a/test/test_gcal_token.py
+++ b/test/test_gcal_token.py
@@ -8,12 +8,12 @@ from unittest.mock import MagicMock, patch
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
 sys.path.insert(0, str(SRC_ROOT))
 
-from gcal.gcal_token import (
+from gcal.gcal_token import (  # noqa: E402
     GoogleToken,
     SettingError,
     _DEFAULT_SCOPES,
     _DEFAULT_TOKEN_URI,
-)  # noqa: E402
+)
 from google.oauth2.credentials import Credentials  # noqa: E402
 from utils.token_crypto import TokenCryptoError, encrypt_token  # noqa: E402
 
@@ -236,6 +236,11 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
         if value == "enc:v1:encrypted-cloud-refresh-token":
             return "plain-cloud-refresh-token"
         raise AssertionError(f"Unexpected token payload: {value}")
+
+    _PLAINTEXT_CLOUD_TOKEN_ERROR = (
+        "Token is not encrypted (expected 'enc:v1:' prefix). "
+        "All tokens in the database must be encrypted."
+    )
 
     def test_cloud_loads_token_from_dynamodb(self):
         with patch(
@@ -563,9 +568,7 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
         ):
             with patch(
                 "gcal.gcal_token.decrypt_token",
-                side_effect=TokenCryptoError(
-                    "Token is not encrypted (expected 'enc:v1:' prefix). All tokens in the database must be encrypted."
-                ),
+                side_effect=TokenCryptoError(self._PLAINTEXT_CLOUD_TOKEN_ERROR),
             ):
                 with patch(
                     "gcal.gcal_token.get_ssm_parameter",
@@ -588,9 +591,7 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
                 "gcal.gcal_token.decrypt_token",
                 side_effect=[
                     "plain-cloud-access-token",
-                    TokenCryptoError(
-                        "Token is not encrypted (expected 'enc:v1:' prefix). All tokens in the database must be encrypted."
-                    ),
+                    TokenCryptoError(self._PLAINTEXT_CLOUD_TOKEN_ERROR),
                 ],
             ):
                 with patch(

--- a/test/test_gcal_token.py
+++ b/test/test_gcal_token.py
@@ -16,8 +16,8 @@ from utils.token_crypto import TokenCryptoError, encrypt_token  # noqa: E402
 _FUTURE_EXPIRY_MS = str(int(datetime(2030, 1, 1, tzinfo=timezone.utc).timestamp() * 1000))
 
 _CLOUD_DYNAMO_RESPONSE = {
-    "accessToken": "cloud-access-token",
-    "refreshToken": "cloud-refresh-token",
+    "accessToken": "enc:v1:encrypted-cloud-access-token",
+    "refreshToken": "enc:v1:encrypted-cloud-refresh-token",
     "expiryDate": _FUTURE_EXPIRY_MS,
 }
 _CLOUD_ENV = {
@@ -212,30 +212,40 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
     def _cloud_config(self, uuid="test-uuid"):
         return {"mode": "cloud", "uuid": uuid}
 
+    def _mock_cloud_decrypt(self, value):
+        if value == "enc:v1:encrypted-cloud-access-token":
+            return "plain-cloud-access-token"
+        if value == "enc:v1:encrypted-cloud-refresh-token":
+            return "plain-cloud-refresh-token"
+        raise AssertionError(f"Unexpected token payload: {value}")
+
     def test_cloud_loads_token_from_dynamodb(self):
         with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE) as mock_loader:
-            with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret") as mock_ssm:
-                with patch.dict(os.environ, _CLOUD_ENV):
-                    gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
+            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
+                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret") as mock_ssm:
+                    with patch.dict(os.environ, _CLOUD_ENV):
+                        gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
                     mock_loader.assert_called_once_with("my-uuid")
                     mock_ssm.assert_called_once_with("/dev/notica/google_calendar_client_secret")
-                    self.assertEqual(gt.credentials.token, "cloud-access-token")
-                    self.assertEqual(gt.credentials.refresh_token, "cloud-refresh-token")
+                    self.assertEqual(gt.credentials.token, "plain-cloud-access-token")
+                    self.assertEqual(gt.credentials.refresh_token, "plain-cloud-refresh-token")
 
     def test_cloud_mode_requires_client_secret_ssm_path(self):
         env = dict(_CLOUD_ENV)
         env.pop("GOOGLE_CALENDAR_CLIENT_SECRET_SSM_PATH")
         with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch.dict(os.environ, env, clear=True):
-                with self.assertRaises(SettingError) as ctx:
-                    GoogleToken(self._cloud_config(), _make_logger())
+            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
+                with patch.dict(os.environ, env, clear=True):
+                    with self.assertRaises(SettingError) as ctx:
+                        GoogleToken(self._cloud_config(), _make_logger())
         self.assertIn("GOOGLE_CALENDAR_CLIENT_SECRET_SSM_PATH", str(ctx.exception))
 
     def test_cloud_mode_fetches_client_secret_from_ssm(self):
         with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret") as mock_ssm:
-                with patch.dict(os.environ, _CLOUD_ENV, clear=True):
-                    gt = GoogleToken(self._cloud_config(), _make_logger())
+            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
+                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret") as mock_ssm:
+                    with patch.dict(os.environ, _CLOUD_ENV, clear=True):
+                        gt = GoogleToken(self._cloud_config(), _make_logger())
         mock_ssm.assert_called_once_with("/dev/notica/google_calendar_client_secret")
         self.assertEqual(gt.credentials.client_secret, "gcal-client-secret")
 
@@ -245,9 +255,10 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             "GOOGLE_CALENDAR_CLIENT_SECRET": "plaintext-secret-should-not-be-read",
         }
         with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.get_ssm_parameter", return_value="ssm-secret-value"):
-                with patch.dict(os.environ, env, clear=True):
-                    gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
+            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
+                with patch("gcal.gcal_token.get_ssm_parameter", return_value="ssm-secret-value"):
+                    with patch.dict(os.environ, env, clear=True):
+                        gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
         self.assertEqual(gt.credentials.client_secret, "ssm-secret-value")
 
     def test_encrypted_cloud_refresh_token_calls_decrypt_token(self):
@@ -257,7 +268,7 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
         }
         with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=response):
             with patch(
-                "gcal.gcal_token.decrypt_token_if_encrypted", return_value="plain-cloud-refresh-token"
+                "gcal.gcal_token.decrypt_token", return_value="plain-cloud-refresh-token"
             ) as mock_decrypt:
                 with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
                     with patch.dict(os.environ, _CLOUD_ENV):
@@ -272,7 +283,7 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
         }
         with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=response):
             with patch(
-                "gcal.gcal_token.decrypt_token_if_encrypted", return_value="plain-cloud-access-token"
+                "gcal.gcal_token.decrypt_token", return_value="plain-cloud-access-token"
             ) as mock_decrypt:
                 with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
                     with patch.dict(os.environ, _CLOUD_ENV):
@@ -282,9 +293,10 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
 
     def test_cloud_save_credentials_calls_dynamodb_updater(self):
         with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
-                with patch.dict(os.environ, _CLOUD_ENV):
-                    gt = GoogleToken(self._cloud_config(), _make_logger())
+            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
+                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+                    with patch.dict(os.environ, _CLOUD_ENV):
+                        gt = GoogleToken(self._cloud_config(), _make_logger())
         mock_creds = MagicMock()
         mock_creds.token = "new-access-token"
         mock_creds.refresh_token = "new-refresh-token"
@@ -304,9 +316,10 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
 
     def test_cloud_save_credentials_writes_encrypted_tokens(self):
         with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
-                with patch.dict(os.environ, _CLOUD_ENV):
-                    gt = GoogleToken(self._cloud_config("uuid-encrypted-save"), _make_logger())
+            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
+                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+                    with patch.dict(os.environ, _CLOUD_ENV):
+                        gt = GoogleToken(self._cloud_config("uuid-encrypted-save"), _make_logger())
         mock_creds = MagicMock()
         mock_creds.token = "new-access-token"
         mock_creds.refresh_token = "new-refresh-token"
@@ -330,9 +343,10 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
 
     def test_cloud_save_credentials_does_not_encrypt_in_gcal_token_layer(self):
         with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
-                with patch.dict(os.environ, _CLOUD_ENV):
-                    gt = GoogleToken(self._cloud_config(), _make_logger())
+            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
+                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+                    with patch.dict(os.environ, _CLOUD_ENV):
+                        gt = GoogleToken(self._cloud_config(), _make_logger())
         mock_creds = MagicMock()
         mock_creds.token = "new-access-token"
         mock_creds.refresh_token = "new-refresh-token"
@@ -385,11 +399,9 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
     def test_cloud_credentials_constructed_with_plaintext_tokens(self):
         response = {
             **_CLOUD_DYNAMO_RESPONSE,
-            "accessToken": "enc:v1:encrypted-cloud-access-token",
-            "refreshToken": "enc:v1:encrypted-cloud-refresh-token",
         }
         with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=response):
-            with patch("gcal.gcal_token.decrypt_token_if_encrypted", side_effect=["plain-access", "plain-refresh"]):
+            with patch("gcal.gcal_token.decrypt_token", side_effect=["plain-access", "plain-refresh"]):
                 with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
                     with patch.dict(os.environ, _CLOUD_ENV, clear=True):
                         gt = GoogleToken(self._cloud_config(), _make_logger())
@@ -407,7 +419,7 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
         }
         with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=response):
             with patch(
-                "gcal.gcal_token.decrypt_token_if_encrypted",
+                "gcal.gcal_token.decrypt_token",
                 side_effect=["enc:v1:still-encrypted", "plain-refresh"],
             ):
                 with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
@@ -416,11 +428,52 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
                             GoogleToken(self._cloud_config(), _make_logger())
         self.assertIn("remained encrypted at runtime", str(ctx.exception))
 
+    def test_cloud_plaintext_access_token_fails_closed(self):
+        response = {
+            **_CLOUD_DYNAMO_RESPONSE,
+            "accessToken": "plain-cloud-access-token",
+            "refreshToken": "enc:v1:encrypted-cloud-refresh-token",
+        }
+        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=response):
+            with patch(
+                "gcal.gcal_token.decrypt_token",
+                side_effect=TokenCryptoError(
+                    "Token is not encrypted (expected 'enc:v1:' prefix). All tokens in the database must be encrypted."
+                ),
+            ):
+                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+                    with patch.dict(os.environ, _CLOUD_ENV, clear=True):
+                        with self.assertRaises(SettingError) as ctx:
+                            GoogleToken(self._cloud_config(), _make_logger())
+        self.assertIn("Token is not encrypted", str(ctx.exception))
+
+    def test_cloud_plaintext_refresh_token_fails_closed(self):
+        response = {
+            **_CLOUD_DYNAMO_RESPONSE,
+            "refreshToken": "plain-cloud-refresh-token",
+        }
+        with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=response):
+            with patch(
+                "gcal.gcal_token.decrypt_token",
+                side_effect=[
+                    "plain-cloud-access-token",
+                    TokenCryptoError(
+                        "Token is not encrypted (expected 'enc:v1:' prefix). All tokens in the database must be encrypted."
+                    ),
+                ],
+            ):
+                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+                    with patch.dict(os.environ, _CLOUD_ENV, clear=True):
+                        with self.assertRaises(SettingError) as ctx:
+                            GoogleToken(self._cloud_config(), _make_logger())
+        self.assertIn("Token is not encrypted", str(ctx.exception))
+
     def test_cloud_refresh_preserves_existing_refresh_token_when_omitted(self):
         with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
-                with patch.dict(os.environ, _CLOUD_ENV, clear=True):
-                    gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
+            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
+                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+                    with patch.dict(os.environ, _CLOUD_ENV, clear=True):
+                        gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
 
         original_refresh = gt.credentials.refresh_token
 
@@ -438,9 +491,10 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
 
     def test_cloud_save_credentials_sets_updated_at_to_now_not_expiry(self):
         with patch("utils.dynamodb_utils.get_google_token_by_uuid", return_value=_CLOUD_DYNAMO_RESPONSE):
-            with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
-                with patch.dict(os.environ, _CLOUD_ENV, clear=True):
-                    gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
+            with patch("gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt):
+                with patch("gcal.gcal_token.get_ssm_parameter", return_value="gcal-client-secret"):
+                    with patch.dict(os.environ, _CLOUD_ENV, clear=True):
+                        gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
 
         mock_creds = MagicMock()
         mock_creds.token = "new-access-token"

--- a/test/test_lambda_utils.py
+++ b/test/test_lambda_utils.py
@@ -92,8 +92,6 @@ class TestProcessAndLogSyncResult(unittest.TestCase):
                             "error_code": "provider_write_failed",
                             "error": "raw provider payload with private content",
                             "debug_detail": "RuntimeError: raw provider payload with private content",
-                            "gcal_event_title": "Private calendar event",
-                            "notion_task_name": "Private task",
                             "gcal_event_start": "2026-05-23T10:00:00Z",
                             "gcal_event_id": "evt-123",
                             "notion_task_id": "page-456",
@@ -118,18 +116,23 @@ class TestProcessAndLogSyncResult(unittest.TestCase):
         returned_error = result["message"]["errors"][0]
 
         self.assertEqual(saved_error["error_code"], "provider_write_failed")
-        self.assertEqual(saved_error["error_message"], lambda_utils.SAFE_SYNC_FAILURE_MESSAGE)
+        self.assertEqual(
+            saved_error["error_message"], lambda_utils.SAFE_SYNC_FAILURE_MESSAGE
+        )
         self.assertIsNone(saved_error["error"])
         self.assertEqual(saved_error["gcal_event_id"], "evt-123")
         self.assertEqual(saved_error["notion_task_id"], "page-456")
-        self.assertEqual(saved_error["gcal_event_title"], "Private calendar event")
-        self.assertEqual(saved_error["notion_task_name"], "Private task")
         self.assertEqual(saved_error["gcal_event_start"], "2026-05-23T10:00:00Z")
+        self.assertNotIn("gcal_event_title", saved_error)
+        self.assertNotIn("notion_task_name", saved_error)
         self.assertNotIn("debug_detail", saved_error)
-        self.assertEqual(returned_error["error"], "raw provider payload with private content")
-        self.assertEqual(returned_error["debug_detail"], "RuntimeError: raw provider payload with private content")
-        self.assertEqual(returned_error["gcal_event_title"], "Private calendar event")
-        self.assertEqual(returned_error["notion_task_name"], "Private task")
+        self.assertEqual(
+            returned_error["error"], "raw provider payload with private content"
+        )
+        self.assertEqual(
+            returned_error["debug_detail"],
+            "RuntimeError: raw provider payload with private content",
+        )
 
     def test_normalizes_plaintext_5xx_failure_message_for_persisted_payload(self):
         sync_result = {
@@ -206,6 +209,80 @@ class TestProcessSqsRecords(unittest.TestCase):
         self.assertEqual(result["failure_count"], 0)
         self.assertCountEqual(result["success_uuids"], uuids)
         self.assertEqual(result["failure_uuids"], [])
+        self.assertEqual(result["batchItemFailures"], [])
+
+    def test_record_exception_returns_partial_batch_failure(self):
+        event = _make_sqs_event(["uuid-ok", "uuid-boom"])
+
+        def run_sync(uuid):
+            if uuid == "uuid-boom":
+                raise RuntimeError("sync exploded")
+            return _ok_sync_result()
+
+        with patch.object(lambda_utils, "_save_sync_logs"):
+            result = lambda_utils.process_sqs_records(
+                logger_obj=self.logger,
+                event=event,
+                context=self.ctx,
+                run_sync=run_sync,
+                lambda_start_time=self.start,
+            )
+
+        self.assertEqual(result["success_count"], 1)
+        self.assertEqual(result["failure_count"], 1)
+        self.assertEqual(result["batchItemFailures"], [{"itemIdentifier": "msg-1"}])
+
+    def test_retryable_500_result_returns_partial_batch_failure(self):
+        event = _make_sqs_event(["uuid-fail"])
+
+        def run_sync(uuid):  # noqa: ARG001
+            return {
+                "statusCode": 500,
+                "body": {
+                    "status": "sync_error",
+                    "message": {"error_code": "sync_runtime_error"},
+                },
+            }
+
+        with patch.object(lambda_utils, "_save_sync_logs"):
+            result = lambda_utils.process_sqs_records(
+                logger_obj=self.logger,
+                event=event,
+                context=self.ctx,
+                run_sync=run_sync,
+                lambda_start_time=self.start,
+            )
+
+        self.assertEqual(result["success_count"], 0)
+        self.assertEqual(result["failure_count"], 1)
+        self.assertEqual(result["batchItemFailures"], [{"itemIdentifier": "msg-0"}])
+
+    def test_mixed_batch_only_retries_failed_records(self):
+        event = _make_sqs_event(["uuid-ok", "uuid-fail", "uuid-ok-2"])
+
+        def run_sync(uuid):
+            if uuid == "uuid-fail":
+                return {
+                    "statusCode": 500,
+                    "body": {
+                        "status": "sync_error",
+                        "message": {"error_code": "sync_runtime_error"},
+                    },
+                }
+            return _ok_sync_result()
+
+        with patch.object(lambda_utils, "_save_sync_logs"):
+            result = lambda_utils.process_sqs_records(
+                logger_obj=self.logger,
+                event=event,
+                context=self.ctx,
+                run_sync=run_sync,
+                lambda_start_time=self.start,
+            )
+
+        self.assertEqual(result["success_count"], 2)
+        self.assertEqual(result["failure_count"], 1)
+        self.assertEqual(result["batchItemFailures"], [{"itemIdentifier": "msg-1"}])
 
 
 if __name__ == "__main__":

--- a/test/test_notion_token.py
+++ b/test/test_notion_token.py
@@ -91,8 +91,13 @@ class TestNotionTokenLocalMode(unittest.TestCase):
 class TestNotionTokenCloudMode(unittest.TestCase):
     def test_cloud_calls_dynamodb(self):
         mock_response = {"accessToken": "enc:v1:encrypted-cloud-notion-token"}
-        with patch("utils.dynamodb_utils.get_notion_token_by_uuid", return_value=mock_response) as mock_db:
-            with patch("notion.notion_token.decrypt_token", return_value="plain-cloud-notion-token") as mock_decrypt:
+        with patch(
+            "utils.dynamodb_utils.get_notion_token_by_uuid", return_value=mock_response
+        ) as mock_db:
+            with patch(
+                "notion.notion_token.decrypt_token",
+                return_value="plain-cloud-notion-token",
+            ) as mock_decrypt:
                 nt = NotionToken(_cloud_config("uuid-abc"), _make_logger())
             mock_db.assert_called_once_with("uuid-abc")
             mock_decrypt.assert_called_once_with("enc:v1:encrypted-cloud-notion-token")
@@ -100,7 +105,9 @@ class TestNotionTokenCloudMode(unittest.TestCase):
 
     def test_cloud_plaintext_token_fails_closed(self):
         mock_response = {"accessToken": "cloud-token-xyz"}
-        with patch("utils.dynamodb_utils.get_notion_token_by_uuid", return_value=mock_response):
+        with patch(
+            "utils.dynamodb_utils.get_notion_token_by_uuid", return_value=mock_response
+        ):
             with patch.dict(os.environ, {}, clear=True):
                 with self.assertRaises(SettingError) as ctx:
                     NotionToken(_cloud_config("uuid-abc"), _make_logger())
@@ -109,7 +116,9 @@ class TestNotionTokenCloudMode(unittest.TestCase):
     def test_cloud_encrypted_token_calls_decrypt_token_if_encrypted(self):
         encrypted_token = "enc:v1:encrypted-cloud-notion-token"
         mock_response = {"accessToken": encrypted_token}
-        with patch("utils.dynamodb_utils.get_notion_token_by_uuid", return_value=mock_response) as mock_db:
+        with patch(
+            "utils.dynamodb_utils.get_notion_token_by_uuid", return_value=mock_response
+        ) as mock_db:
             with patch(
                 "notion.notion_token.decrypt_token",
                 return_value="plain-cloud-notion-token",
@@ -122,7 +131,9 @@ class TestNotionTokenCloudMode(unittest.TestCase):
     def test_cloud_encrypted_token_missing_key_raises_setting_error(self):
         encrypted_token = "enc:v1:encrypted-cloud-notion-token"
         mock_response = {"accessToken": encrypted_token}
-        with patch("utils.dynamodb_utils.get_notion_token_by_uuid", return_value=mock_response):
+        with patch(
+            "utils.dynamodb_utils.get_notion_token_by_uuid", return_value=mock_response
+        ):
             with patch(
                 "notion.notion_token.decrypt_token",
                 side_effect=TokenCryptoError("TOKEN_ENCRYPTION_KEY missing"),
@@ -133,7 +144,10 @@ class TestNotionTokenCloudMode(unittest.TestCase):
         self.assertIn("TOKEN_ENCRYPTION_KEY", str(ctx.exception))
 
     def test_cloud_dynamodb_error_raises_setting_error(self):
-        with patch("utils.dynamodb_utils.get_notion_token_by_uuid", side_effect=RuntimeError("DDB down")):
+        with patch(
+            "utils.dynamodb_utils.get_notion_token_by_uuid",
+            side_effect=RuntimeError("DDB down"),
+        ):
             with self.assertRaises(SettingError) as ctx:
                 NotionToken(_cloud_config(), _make_logger())
             self.assertIn("DDB down", str(ctx.exception))

--- a/test/test_notion_token.py
+++ b/test/test_notion_token.py
@@ -90,25 +90,28 @@ class TestNotionTokenLocalMode(unittest.TestCase):
 
 class TestNotionTokenCloudMode(unittest.TestCase):
     def test_cloud_calls_dynamodb(self):
-        mock_response = {"accessToken": "cloud-token-xyz"}
+        mock_response = {"accessToken": "enc:v1:encrypted-cloud-notion-token"}
         with patch("utils.dynamodb_utils.get_notion_token_by_uuid", return_value=mock_response) as mock_db:
-            nt = NotionToken(_cloud_config("uuid-abc"), _make_logger())
+            with patch("notion.notion_token.decrypt_token", return_value="plain-cloud-notion-token") as mock_decrypt:
+                nt = NotionToken(_cloud_config("uuid-abc"), _make_logger())
             mock_db.assert_called_once_with("uuid-abc")
-            self.assertEqual(nt.get(), "cloud-token-xyz")
+            mock_decrypt.assert_called_once_with("enc:v1:encrypted-cloud-notion-token")
+            self.assertEqual(nt.get(), "plain-cloud-notion-token")
 
-    def test_cloud_plaintext_token_works_without_encryption_key(self):
+    def test_cloud_plaintext_token_fails_closed(self):
         mock_response = {"accessToken": "cloud-token-xyz"}
         with patch("utils.dynamodb_utils.get_notion_token_by_uuid", return_value=mock_response):
             with patch.dict(os.environ, {}, clear=True):
-                nt = NotionToken(_cloud_config("uuid-abc"), _make_logger())
-        self.assertEqual(nt.get(), "cloud-token-xyz")
+                with self.assertRaises(SettingError) as ctx:
+                    NotionToken(_cloud_config("uuid-abc"), _make_logger())
+        self.assertIn("Token is not encrypted", str(ctx.exception))
 
     def test_cloud_encrypted_token_calls_decrypt_token_if_encrypted(self):
         encrypted_token = "enc:v1:encrypted-cloud-notion-token"
         mock_response = {"accessToken": encrypted_token}
         with patch("utils.dynamodb_utils.get_notion_token_by_uuid", return_value=mock_response) as mock_db:
             with patch(
-                "notion.notion_token.decrypt_token_if_encrypted",
+                "notion.notion_token.decrypt_token",
                 return_value="plain-cloud-notion-token",
             ) as mock_decrypt:
                 nt = NotionToken(_cloud_config("uuid-abc"), _make_logger())
@@ -121,7 +124,7 @@ class TestNotionTokenCloudMode(unittest.TestCase):
         mock_response = {"accessToken": encrypted_token}
         with patch("utils.dynamodb_utils.get_notion_token_by_uuid", return_value=mock_response):
             with patch(
-                "notion.notion_token.decrypt_token_if_encrypted",
+                "notion.notion_token.decrypt_token",
                 side_effect=TokenCryptoError("TOKEN_ENCRYPTION_KEY missing"),
             ):
                 with self.assertRaises(SettingError) as ctx:

--- a/test/test_sync_log_contract.py
+++ b/test/test_sync_log_contract.py
@@ -77,8 +77,6 @@ class SyncContractTests(unittest.TestCase):
                             "action": "update_notion",
                             "error_code": "runtime_error",
                             "error": "provider failure",
-                            "gcal_event_title": "title",
-                            "notion_task_name": "task",
                             "gcal_event_start": "2026-05-23T09:00:00+08:00",
                             "gcal_event_id": "evt-1",
                             "notion_task_id": "page-1",
@@ -114,7 +112,9 @@ class SyncContractTests(unittest.TestCase):
             "duration_ms",
         }
         self.assertTrue(required_top_level_keys.issubset(payload.keys()))
-        self.assertEqual(payload["contract_version"], lambda_utils.SYNC_LOG_CONTRACT_VERSION)
+        self.assertEqual(
+            payload["contract_version"], lambda_utils.SYNC_LOG_CONTRACT_VERSION
+        )
 
         persisted_errors = payload["message"]["errors"]
         self.assertEqual(len(persisted_errors), 1)
@@ -124,8 +124,6 @@ class SyncContractTests(unittest.TestCase):
             "error_code",
             "error_message",
             "error",
-            "gcal_event_title",
-            "notion_task_name",
             "gcal_event_start",
             "gcal_event_id",
             "notion_task_id",

--- a/test/test_sync_sanitization.py
+++ b/test/test_sync_sanitization.py
@@ -45,7 +45,10 @@ class SyncSanitizationTests(unittest.TestCase):
     def test_sync_errors_expose_safe_message_for_retriable_failures(self):
         notion_service = MagicMock()
         google_service = MagicMock()
-        notion_service.get_notion_task.return_value = ({}, [_make_notion_task("evt-123")])
+        notion_service.get_notion_task.return_value = (
+            {},
+            [_make_notion_task("evt-123")],
+        )
         notion_service.update_notion_task.side_effect = RuntimeError(
             "private provider payload: secret summary and customer data"
         )
@@ -73,20 +76,26 @@ class SyncSanitizationTests(unittest.TestCase):
         error = result["body"]["message"]["errors"][0]
         self.assertEqual(error["action"], "update_notion")
         self.assertEqual(error["error_code"], "runtime_error")
-        self.assertEqual(error["error_message"], "Sync failed. See Lambda logs with aws_request_id for details.")
+        self.assertEqual(
+            error["error_message"],
+            "Sync failed. See Lambda logs with aws_request_id for details.",
+        )
         self.assertIsNone(error["error"])
         self.assertEqual(error["notion_task_id"], "page-123")
-        self.assertEqual(error["notion_task_name"], "Highly sensitive task title")
         self.assertEqual(error["gcal_event_id"], "evt-123")
-        self.assertEqual(error["gcal_event_title"], "Private calendar summary")
         self.assertEqual(error["gcal_event_start"], "2026-05-23T09:00:00+08:00")
         self.assertTrue(error["retriable"])
+        self.assertNotIn("notion_task_name", error)
+        self.assertNotIn("gcal_event_title", error)
         self.assertNotIn("debug_detail", error)
 
     def test_sync_errors_include_debug_detail_only_with_explicit_non_prod_flag(self):
         notion_service = MagicMock()
         google_service = MagicMock()
-        notion_service.get_notion_task.return_value = ({}, [_make_notion_task("evt-123")])
+        notion_service.get_notion_task.return_value = (
+            {},
+            [_make_notion_task("evt-123")],
+        )
         notion_service.update_notion_task.side_effect = RuntimeError(
             "private provider payload: secret summary and customer data"
         )
@@ -117,7 +126,10 @@ class SyncSanitizationTests(unittest.TestCase):
 
         self.assertEqual(result["statusCode"], 200)
         error = result["body"]["message"]["errors"][0]
-        self.assertEqual(error["error_message"], "Sync failed. See Lambda logs with aws_request_id for details.")
+        self.assertEqual(
+            error["error_message"],
+            "Sync failed. See Lambda logs with aws_request_id for details.",
+        )
         self.assertIsNone(error["error"])
         self.assertIn("debug_detail", error)
         self.assertIn("RuntimeError", error["debug_detail"])


### PR DESCRIPTION
## What changed

- return SQS `batchItemFailures` so record-level failures and retryable `500` sync results are retried instead of being silently acknowledged
- remove Notion task titles and Google event titles from persisted sync-log error payloads
- update the sync-log contract documentation and targeted tests for the new sanitized payload shape
- replace a couple of production log lines that previously emitted Google event summary content with ID-only logging

## Why

This PR addresses two production issues in the Lambda worker:

- failed SQS records were being summarized in logs but still acknowledged, which could drop sync work without retry
- persisted sync logs still carried user content fields (`notion_task_name`, `gcal_event_title`), which widened exposure of calendar/task content in DynamoDB and observability surfaces

## Root cause

- `process_sqs_records(...)` aggregated failures but never returned Lambda partial batch failure data back to SQS
- sync error payload construction and sanitization preserved title fields even for persisted sync-log records, and some production logs still interpolated event summaries directly

## Validation

- `uv run python -m unittest discover -s test -p 'test_lambda_utils.py' -v`
- `uv run python -m unittest discover -s test -p 'test_sync_sanitization.py' -v`
- `uv run python -m unittest discover -s test -p 'test_sync_log_contract.py' -v`
- `uv run black --check src/utils/lambda_utils.py src/sync/sync.py src/notion/notion_service.py src/gcal/gcal_service.py test/test_lambda_utils.py test/test_sync_sanitization.py test/test_sync_log_contract.py`
- `uv run flake8 --max-line-length=120 src/utils/lambda_utils.py src/sync/sync.py src/notion/notion_service.py src/gcal/gcal_service.py test/test_lambda_utils.py test/test_sync_sanitization.py test/test_sync_log_contract.py`

## Fixed issues

Fixes #93
Fixes #94
