### PR TITLE
[ISSUE-97]: FAIL-CLOSED-LAMBDA-HANDLER

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -20,22 +20,49 @@ from src.utils.lambda_utils import detect_event_source, process_sqs_records, pro
 logger_obj = get_logger(__name__)
 
 
+SAFE_SYNC_FAILURE_MESSAGE = "Sync failed. See Lambda logs with aws_request_id for details."
+
+
+def _all_sqs_batch_failures(event: Dict[str, Any]) -> list[Dict[str, str]]:
+    failures = []
+    for record in event.get("Records", []):
+        if record.get("eventSource") == "aws:sqs":
+            failures.append({"itemIdentifier": record.get("messageId", "unknown")})
+    return failures
+
+
+def _safe_error_payload(context: Any, error_code: str, status_code: int = 500) -> Dict[str, Any]:
+    return {
+        "statusCode": status_code,
+        "body": {
+            "status": "sync_error",
+            "message": {
+                "error_code": error_code,
+                "error_message": SAFE_SYNC_FAILURE_MESSAGE,
+                "aws_request_id": getattr(context, "aws_request_id", "unknown"),
+            },
+        },
+    }
+
+
 # Main Lambda handler: dispatch to SQS or API event processing
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """AWS Lambda handler: dispatches to SQS or API helpers and centralises error handling."""
     lambda_start_time = datetime.now(timezone.utc)
 
-    # Import here to preserve original lazy import behaviour used in the project
-    from src.main import main as run_sync_notion_and_google  # noqa: E402
-
     try:
         event_type = detect_event_source(logger_obj, event)
         if event_type == "api":
-            pass  # API event processing can be added here (e.g. test connection)
+            logger_obj.warning("API event processing is not implemented for this Lambda.")
+            return _safe_error_payload(context, "unsupported_event_source", status_code=501)
         elif event_type == "sqs":
+            from src.main import main as run_sync_notion_and_google  # noqa: E402
+
             message = process_sqs_records(logger_obj, event, context, run_sync_notion_and_google, lambda_start_time)
             return message
         elif event_type == "eventbridge":
+            from src.main import main as run_sync_notion_and_google  # noqa: E402
+
             message = process_eventbridge_event(
                 logger_obj, event, context, run_sync_notion_and_google, lambda_start_time
             )
@@ -46,8 +73,20 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
     except RefreshError as e:
         logger_obj.exception(f"Google token refresh failed {e}")
+        if _all_sqs_batch_failures(event):
+            return {
+                "batchItemFailures": _all_sqs_batch_failures(event),
+                **_safe_error_payload(context, "google_refresh_error"),
+            }
+        return _safe_error_payload(context, "google_refresh_error")
     except Exception as e:
         logger_obj.exception(f"Unhandled lambda error {e}")
+        if _all_sqs_batch_failures(event):
+            return {
+                "batchItemFailures": _all_sqs_batch_failures(event),
+                **_safe_error_payload(context, "lambda_unhandled_error"),
+            }
+        return _safe_error_payload(context, "lambda_unhandled_error")
 
 
 # --- Local test entrypoint ---

--- a/test/test_lambda_handler.py
+++ b/test/test_lambda_handler.py
@@ -1,0 +1,127 @@
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+google_module = types.ModuleType("google")
+google_auth_module = types.ModuleType("google.auth")
+google_auth_exceptions_module = types.ModuleType("google.auth.exceptions")
+
+
+class _RefreshError(Exception):
+    pass
+
+
+google_auth_exceptions_module.RefreshError = _RefreshError
+google_auth_module.exceptions = google_auth_exceptions_module
+google_module.auth = google_auth_module
+sys.modules.setdefault("google", google_module)
+sys.modules.setdefault("google.auth", google_auth_module)
+sys.modules.setdefault("google.auth.exceptions", google_auth_exceptions_module)
+
+import lambda_function  # noqa: E402
+from google.auth.exceptions import RefreshError  # noqa: E402
+
+
+def _make_context(function_name="test-lambda", aws_request_id="req-123"):
+    return type(
+        "FakeContext",
+        (),
+        {
+            "function_name": function_name,
+            "aws_request_id": aws_request_id,
+        },
+    )()
+
+
+def _make_sqs_event(*uuids):
+    return {
+        "Records": [
+            {
+                "messageId": f"msg-{index}",
+                "body": json.dumps({"uuid": uuid}),
+                "eventSource": "aws:sqs",
+            }
+            for index, uuid in enumerate(uuids)
+        ]
+    }
+
+
+class LambdaHandlerTests(unittest.TestCase):
+    def _stub_src_main(self):
+        module = types.ModuleType("src.main")
+        module.main = lambda uuid=None: {"statusCode": 200, "body": {"status": "sync_success", "message": uuid}}
+        return patch.dict(sys.modules, {"src.main": module})
+
+    def test_api_event_returns_explicit_501_payload(self):
+        event = {"requestContext": {"http": {"method": "POST"}}}
+        context = _make_context()
+
+        with patch.object(lambda_function, "detect_event_source", return_value="api"):
+            result = lambda_function.lambda_handler(event, context)
+
+        self.assertEqual(result["statusCode"], 501)
+        self.assertEqual(result["body"]["status"], "sync_error")
+        self.assertEqual(result["body"]["message"]["error_code"], "unsupported_event_source")
+        self.assertEqual(result["body"]["message"]["aws_request_id"], "req-123")
+
+    def test_unhandled_sqs_failure_returns_all_batch_item_failures(self):
+        event = _make_sqs_event("uuid-1", "uuid-2")
+        context = _make_context()
+
+        with self._stub_src_main():
+            with patch.object(lambda_function, "detect_event_source", return_value="sqs"):
+                with patch.object(
+                    lambda_function,
+                    "process_sqs_records",
+                    side_effect=RuntimeError("boom"),
+                ):
+                    result = lambda_function.lambda_handler(event, context)
+
+        self.assertEqual(result["statusCode"], 500)
+        self.assertEqual(
+            result["batchItemFailures"],
+            [{"itemIdentifier": "msg-0"}, {"itemIdentifier": "msg-1"}],
+        )
+        self.assertEqual(result["body"]["message"]["error_code"], "lambda_unhandled_error")
+
+    def test_refresh_error_returns_sqs_batch_item_failures(self):
+        event = _make_sqs_event("uuid-1")
+        context = _make_context()
+
+        with self._stub_src_main():
+            with patch.object(lambda_function, "detect_event_source", return_value="sqs"):
+                with patch.object(
+                    lambda_function,
+                    "process_sqs_records",
+                    side_effect=RefreshError("invalid_grant"),
+                ):
+                    result = lambda_function.lambda_handler(event, context)
+
+        self.assertEqual(result["statusCode"], 500)
+        self.assertEqual(result["batchItemFailures"], [{"itemIdentifier": "msg-0"}])
+        self.assertEqual(result["body"]["message"]["error_code"], "google_refresh_error")
+
+    def test_detect_event_source_failure_returns_safe_500_payload(self):
+        event = {"detail-type": "scheduled", "source": "aws.events"}
+        context = _make_context()
+
+        with patch.object(
+            lambda_function,
+            "detect_event_source",
+            side_effect=RuntimeError("broken detector"),
+        ):
+            result = lambda_function.lambda_handler(event, context)
+
+        self.assertEqual(result["statusCode"], 500)
+        self.assertEqual(result["body"]["status"], "sync_error")
+        self.assertEqual(result["body"]["message"]["error_code"], "lambda_unhandled_error")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fail closed for unsupported API and top-level Lambda error paths
- return `batchItemFailures` for SQS-wide failures instead of falling through
- add regression tests for API, detector, refresh, and SQS exception paths

## Context
- Fixes #97

## Validation
- `python3 -m unittest discover -s test -p 'test_lambda_handler.py'`
- `python3 -m unittest discover -s test -p 'test_lambda_utils.py'`

Linked Issue: [[P1 Bug] Lambda handler swallows top-level failures and can acknowledge failed invocations](https://github.com/HUIXIN-TW/NotionSyncGCal/issues/97)
Fixes #97
