### PR TITLE
[ISSUE-98]: CONDITIONAL-GOOGLE-TOKEN-WRITE

### DIFF
--- a/src/gcal/gcal_token.py
+++ b/src/gcal/gcal_token.py
@@ -34,6 +34,7 @@ class GoogleToken:
         self.config = config
         self.mode = config.get("mode")
         self.logger = logger
+        self._loaded_updated_at = None
         self.activate_token()
 
     def activate_token(self):
@@ -55,6 +56,7 @@ class GoogleToken:
 
                 self.logger.debug("Loading credentials from DynamoDB")
                 data = get_google_token_by_uuid(self.config.get("uuid"))
+                self._loaded_updated_at = data.get("updatedAt")
                 try:
                     access_token = decrypt_token(data.get("accessToken"))
                     refresh_token = decrypt_token(data.get("refreshToken"))
@@ -164,7 +166,9 @@ class GoogleToken:
                     credentials.refresh_token,
                     expiry_str,
                     updated_str,
+                    self._loaded_updated_at,
                 )
+                self._loaded_updated_at = updated_str
                 self.logger.info("Saved credentials to DynamoDB.")
             elif self.mode == "local":
                 self.logger.debug("Local mode: skipping credential persistence.")

--- a/src/utils/dynamodb_utils.py
+++ b/src/utils/dynamodb_utils.py
@@ -103,10 +103,28 @@ def get_google_token_by_uuid(uuid: str) -> str:
 
 
 # update item in google oauth token tables by uuid
-def update_google_token_by_uuid(uuid: str, access_token: str, refresh_token: str, expiry_date: str, updated_at: str):
+def update_google_token_by_uuid(
+    uuid: str,
+    access_token: str,
+    refresh_token: str,
+    expiry_date: str,
+    updated_at: str,
+    expected_updated_at: str | None = None,
+):
     google_tbl = _get_google_tables()
     encrypted_access_token = encrypt_token_if_plaintext(access_token)
     encrypted_refresh_token = encrypt_token_if_plaintext(refresh_token)
+    expression_attribute_values = {
+        ":at": encrypted_access_token,
+        ":rt": encrypted_refresh_token,
+        ":expiry": expiry_date,
+        ":updated": updated_at,
+    }
+    if expected_updated_at is None:
+        condition_expression = "attribute_not_exists(updatedAt)"
+    else:
+        condition_expression = "attribute_not_exists(updatedAt) OR updatedAt = :expected_updated"
+        expression_attribute_values[":expected_updated"] = expected_updated_at
     google_tbl.update_item(
         Key={"uuid": uuid},
         UpdateExpression="""
@@ -115,12 +133,8 @@ def update_google_token_by_uuid(uuid: str, access_token: str, refresh_token: str
                 expiryDate = :expiry,
                 updatedAt = :updated
         """,
-        ExpressionAttributeValues={
-            ":at": encrypted_access_token,
-            ":rt": encrypted_refresh_token,
-            ":expiry": expiry_date,
-            ":updated": updated_at,
-        },
+        ConditionExpression=condition_expression,
+        ExpressionAttributeValues=expression_attribute_values,
     )
 
 

--- a/test/test_dynamodb_utils.py
+++ b/test/test_dynamodb_utils.py
@@ -1,10 +1,15 @@
 import sys
+import types
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
 sys.path.insert(0, str(SRC_ROOT))
+
+boto3_module = types.ModuleType("boto3")
+boto3_module.resource = MagicMock()
+sys.modules.setdefault("boto3", boto3_module)
 
 from utils.dynamodb_utils import (  # noqa: E402
     get_google_token_by_uuid,
@@ -50,7 +55,7 @@ class DynamoDbGoogleTokenTests(unittest.TestCase):
                 side_effect=["enc:v1:access", "enc:v1:refresh"],
             ) as mock_encrypt:
                 update_google_token_by_uuid(
-                    "u-1", "plain-access", "plain-refresh", "111", "222"
+                    "u-1", "plain-access", "plain-refresh", "111", "222", "123"
                 )
 
         self.assertEqual(mock_encrypt.call_args_list[0].args[0], "plain-access")
@@ -62,6 +67,11 @@ class DynamoDbGoogleTokenTests(unittest.TestCase):
         self.assertEqual(kwargs["ExpressionAttributeValues"][":rt"], "enc:v1:refresh")
         self.assertEqual(kwargs["ExpressionAttributeValues"][":expiry"], "111")
         self.assertEqual(kwargs["ExpressionAttributeValues"][":updated"], "222")
+        self.assertEqual(kwargs["ExpressionAttributeValues"][":expected_updated"], "123")
+        self.assertEqual(
+            kwargs["ConditionExpression"],
+            "attribute_not_exists(updatedAt) OR updatedAt = :expected_updated",
+        )
 
     def test_update_google_token_does_not_double_encrypt_prefixed_values(self):
         table = MagicMock()
@@ -72,7 +82,7 @@ class DynamoDbGoogleTokenTests(unittest.TestCase):
                 "utils.dynamodb_utils.encrypt_token_if_plaintext",
                 side_effect=[access, refresh],
             ):
-                update_google_token_by_uuid("u-1", access, refresh, "111", "222")
+                update_google_token_by_uuid("u-1", access, refresh, "111", "222", "123")
 
         values = table.update_item.call_args.kwargs["ExpressionAttributeValues"]
         self.assertEqual(values[":at"], access)
@@ -87,9 +97,22 @@ class DynamoDbGoogleTokenTests(unittest.TestCase):
             ):
                 with self.assertRaises(TokenCryptoError):
                     update_google_token_by_uuid(
-                        "u-1", "enc:v1:broken", "plain-refresh", "111", "222"
+                        "u-1", "enc:v1:broken", "plain-refresh", "111", "222", "123"
                     )
         table.update_item.assert_not_called()
+
+    def test_update_google_token_uses_attribute_not_exists_guard_when_row_has_no_updated_at(self):
+        table = MagicMock()
+        with patch("utils.dynamodb_utils._get_google_tables", return_value=table):
+            with patch(
+                "utils.dynamodb_utils.encrypt_token_if_plaintext",
+                side_effect=["enc:v1:access", "enc:v1:refresh"],
+            ):
+                update_google_token_by_uuid("u-1", "plain-access", "plain-refresh", "111", "222")
+
+        kwargs = table.update_item.call_args.kwargs
+        self.assertEqual(kwargs["ConditionExpression"], "attribute_not_exists(updatedAt)")
+        self.assertNotIn(":expected_updated", kwargs["ExpressionAttributeValues"])
 
 
 if __name__ == "__main__":

--- a/test/test_gcal_token.py
+++ b/test/test_gcal_token.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import types
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
@@ -8,6 +9,86 @@ from unittest.mock import MagicMock, patch
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
 sys.path.insert(0, str(SRC_ROOT))
 
+
+class _FakeRequest:
+    pass
+
+
+class _FakeRefreshError(Exception):
+    pass
+
+
+class _FakeCredentials:
+    def __init__(
+        self,
+        token=None,
+        refresh_token=None,
+        token_uri=None,
+        client_id=None,
+        client_secret=None,
+        scopes=None,
+        expiry=None,
+    ):
+        self.token = token
+        self.refresh_token = refresh_token
+        self._refresh_token = refresh_token
+        self.token_uri = token_uri
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.scopes = scopes
+        self.expiry = expiry
+
+    @property
+    def expired(self):
+        if self.expiry is None:
+            return False
+        expiry = self.expiry
+        if expiry.tzinfo is None:
+            expiry = expiry.replace(tzinfo=timezone.utc)
+        return expiry <= datetime.now(timezone.utc)
+
+    @property
+    def refresh_token(self):
+        return self._refresh_token
+
+    @refresh_token.setter
+    def refresh_token(self, value):
+        self._refresh_token = value
+
+    def refresh(self, request):  # noqa: ARG002
+        raise NotImplementedError("Patched in tests")
+
+
+google_module = types.ModuleType("google")
+google_auth_module = types.ModuleType("google.auth")
+google_auth_transport_module = types.ModuleType("google.auth.transport")
+google_auth_transport_requests_module = types.ModuleType("google.auth.transport.requests")
+google_auth_exceptions_module = types.ModuleType("google.auth.exceptions")
+google_oauth2_module = types.ModuleType("google.oauth2")
+google_oauth2_credentials_module = types.ModuleType("google.oauth2.credentials")
+
+google_auth_transport_requests_module.Request = _FakeRequest
+google_auth_transport_module.requests = google_auth_transport_requests_module
+google_auth_exceptions_module.RefreshError = _FakeRefreshError
+google_oauth2_credentials_module.Credentials = _FakeCredentials
+google_oauth2_module.credentials = google_oauth2_credentials_module
+google_auth_module.transport = google_auth_transport_module
+google_auth_module.exceptions = google_auth_exceptions_module
+google_module.auth = google_auth_module
+google_module.oauth2 = google_oauth2_module
+
+sys.modules.setdefault("google", google_module)
+sys.modules.setdefault("google.auth", google_auth_module)
+sys.modules.setdefault("google.auth.transport", google_auth_transport_module)
+sys.modules.setdefault("google.auth.transport.requests", google_auth_transport_requests_module)
+sys.modules.setdefault("google.auth.exceptions", google_auth_exceptions_module)
+sys.modules.setdefault("google.oauth2", google_oauth2_module)
+sys.modules.setdefault("google.oauth2.credentials", google_oauth2_credentials_module)
+
+boto3_module = types.ModuleType("boto3")
+boto3_module.resource = MagicMock()
+sys.modules.setdefault("boto3", boto3_module)
+
 from gcal.gcal_token import (  # noqa: E402
     GoogleToken,
     SettingError,
@@ -15,7 +96,8 @@ from gcal.gcal_token import (  # noqa: E402
     _DEFAULT_TOKEN_URI,
 )
 from google.oauth2.credentials import Credentials  # noqa: E402
-from utils.token_crypto import TokenCryptoError, encrypt_token  # noqa: E402
+from utils.token_crypto import TokenCryptoError  # noqa: E402
+import utils.dynamodb_utils  # noqa: E402,F401
 
 # A far-future expiry in ms — prevents credentials.expired from being True in cloud tests
 _FUTURE_EXPIRY_MS = str(
@@ -26,6 +108,7 @@ _CLOUD_DYNAMO_RESPONSE = {
     "accessToken": "enc:v1:encrypted-cloud-access-token",
     "refreshToken": "enc:v1:encrypted-cloud-refresh-token",
     "expiryDate": _FUTURE_EXPIRY_MS,
+    "updatedAt": "1710000000000",
 }
 _CLOUD_ENV = {
     "GOOGLE_CALENDAR_CLIENT_ID": "gcal-client-id",
@@ -390,6 +473,7 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
                 ):
                     gt._save_credentials(mock_creds)
             mock_updater.assert_called_once()
+        self.assertEqual(mock_updater.call_args[0][5], _CLOUD_DYNAMO_RESPONSE["updatedAt"])
 
     def test_cloud_save_credentials_writes_encrypted_tokens(self):
         with patch(
@@ -427,9 +511,10 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
                 ):
                     gt._save_credentials(mock_creds)
 
-        _, saved_access_token, saved_refresh_token, _, _ = mock_updater.call_args[0]
+        _, saved_access_token, saved_refresh_token, _, _, expected_updated_at = mock_updater.call_args[0]
         self.assertEqual(saved_access_token, "new-access-token")
         self.assertEqual(saved_refresh_token, "new-refresh-token")
+        self.assertEqual(expected_updated_at, _CLOUD_DYNAMO_RESPONSE["updatedAt"])
 
     def test_cloud_save_credentials_does_not_encrypt_in_gcal_token_layer(self):
         with patch(
@@ -457,11 +542,12 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
 
     def test_encrypted_cloud_load_refresh_save_keeps_dynamodb_tokens_encrypted(self):
         expired_response = {
-            "accessToken": None,
-            "refreshToken": None,
+            "accessToken": "enc:v1:expired-access-token",
+            "refreshToken": "enc:v1:expired-refresh-token",
             "expiryDate": str(
                 int(datetime(2000, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
             ),
+            "updatedAt": _CLOUD_DYNAMO_RESPONSE["updatedAt"],
         }
 
         def refresh_credentials(credentials, request):  # noqa: ARG001
@@ -470,21 +556,12 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             credentials.expiry = datetime(2030, 1, 1, tzinfo=timezone.utc)
 
         with patch.dict(
-            os.environ, {"TOKEN_ENCRYPTION_KEY": _TOKEN_ENCRYPTION_KEY}, clear=True
-        ):
-            expired_response["accessToken"] = encrypt_token("old-access-token")
-            expired_response["refreshToken"] = encrypt_token("old-refresh-token")
-
-        with patch.dict(
             os.environ,
             {
                 **_CLOUD_ENV,
-                "APP_MODE": "cloud",
-                "TOKEN_ENCRYPTION_KEY_SSM_PATH": "/dev/notica/token_encryption_key",
             },
             clear=True,
         ):
-
             with patch(
                 "utils.dynamodb_utils.get_google_token_by_uuid",
                 return_value=expired_response,
@@ -497,20 +574,21 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
                         new=refresh_credentials,
                     ):
                         with patch(
-                            "gcal.gcal_token.get_ssm_parameter",
-                            return_value="gcal-client-secret",
+                            "gcal.gcal_token.decrypt_token",
+                            side_effect=["old-access-token", "old-refresh-token"],
                         ):
                             with patch(
-                                "utils.token_crypto.get_ssm_parameter",
-                                return_value=_TOKEN_ENCRYPTION_KEY,
+                                "gcal.gcal_token.get_ssm_parameter",
+                                return_value="gcal-client-secret",
                             ):
                                 gt = GoogleToken(self._cloud_config(), _make_logger())
 
         self.assertEqual(gt.credentials.token, "refreshed-access-token")
         self.assertEqual(gt.credentials.refresh_token, "refreshed-refresh-token")
-        _, saved_access_token, saved_refresh_token, _, _ = mock_updater.call_args[0]
+        _, saved_access_token, saved_refresh_token, _, _, expected_updated_at = mock_updater.call_args[0]
         self.assertEqual(saved_access_token, "refreshed-access-token")
         self.assertEqual(saved_refresh_token, "refreshed-refresh-token")
+        self.assertEqual(expected_updated_at, _CLOUD_DYNAMO_RESPONSE["updatedAt"])
 
     def test_cloud_credentials_constructed_with_plaintext_tokens(self):
         response = {
@@ -634,8 +712,9 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             ) as mock_updater:
                 gt._refresh_tokens(gt.credentials)
 
-        _, _, saved_refresh_token, _, _ = mock_updater.call_args[0]
+        _, _, saved_refresh_token, _, _, expected_updated_at = mock_updater.call_args[0]
         self.assertEqual(saved_refresh_token, original_refresh)
+        self.assertEqual(expected_updated_at, _CLOUD_DYNAMO_RESPONSE["updatedAt"])
 
     def test_cloud_save_credentials_sets_updated_at_to_now_not_expiry(self):
         with patch(
@@ -664,7 +743,7 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
                 )
                 gt._save_credentials(mock_creds)
 
-        _, _, _, expiry_date, updated_at = mock_updater.call_args[0]
+        _, _, _, expiry_date, updated_at, expected_updated_at = mock_updater.call_args[0]
         self.assertEqual(
             expiry_date,
             str(int(datetime(2030, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)),
@@ -674,6 +753,39 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             str(int(datetime(2026, 1, 2, tzinfo=timezone.utc).timestamp() * 1000)),
         )
         self.assertNotEqual(updated_at, expiry_date)
+        self.assertEqual(expected_updated_at, _CLOUD_DYNAMO_RESPONSE["updatedAt"])
+
+    def test_cloud_refresh_updates_loaded_updated_at_after_successful_save(self):
+        with patch(
+            "utils.dynamodb_utils.get_google_token_by_uuid",
+            return_value=_CLOUD_DYNAMO_RESPONSE,
+        ):
+            with patch(
+                "gcal.gcal_token.decrypt_token", side_effect=self._mock_cloud_decrypt
+            ):
+                with patch(
+                    "gcal.gcal_token.get_ssm_parameter",
+                    return_value="gcal-client-secret",
+                ):
+                    with patch.dict(os.environ, _CLOUD_ENV, clear=True):
+                        gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
+
+        mock_creds = MagicMock()
+        mock_creds.token = "new-access-token"
+        mock_creds.refresh_token = "new-refresh-token"
+        mock_creds.expiry = datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+        with patch("utils.dynamodb_utils.update_google_token_by_uuid"):
+            with patch("gcal.gcal_token.datetime") as mock_datetime:
+                mock_datetime.now.return_value = datetime(
+                    2026, 1, 2, tzinfo=timezone.utc
+                )
+                gt._save_credentials(mock_creds)
+
+        self.assertEqual(
+            gt._loaded_updated_at,
+            str(int(datetime(2026, 1, 2, tzinfo=timezone.utc).timestamp() * 1000)),
+        )
 
     def test_cloud_dynamodb_error_raises_setting_error(self):
         with patch(


### PR DESCRIPTION
## Summary
- carry the loaded Google token row `updatedAt` through refresh persistence
- add a DynamoDB conditional write guard to prevent stale token overwrites
- extend focused tests for the write contract and refresh flow

## Context
- Fixes #98

## Validation
- `python3 -m unittest discover -s test -p 'test_dynamodb_utils.py'`
- `python3 -m unittest discover -s test -p 'test_gcal_token.py'`
- `python3 -m py_compile src/gcal/gcal_token.py src/utils/dynamodb_utils.py test/test_dynamodb_utils.py test/test_gcal_token.py`

Linked Issue: [[P2 Data Access] Google OAuth refresh writes can overwrite newer token rows without concurrency checks](https://github.com/HUIXIN-TW/NotionSyncGCal/issues/98)
Fixes #98
