### PR TITLE
CODEX/DOCS-SYNC-20260613

### DIFF
--- a/docs/local-dev-sync-runner.md
+++ b/docs/local-dev-sync-runner.md
@@ -106,12 +106,12 @@ Do not commit `.env.local` or any generated env snippet. Refresh-token generatio
 
 ## Encrypted Tokens
 
-Local and cloud token values may be plaintext or `enc:v1:` encrypted:
+Local tokens may be plaintext or `enc:v1:` encrypted. Cloud DynamoDB token rows must already be `enc:v1:` encrypted:
 
 - Plaintext `NOTION_TOKEN` and `GOOGLE_REFRESH_TOKEN` work without `TOKEN_ENCRYPTION_KEY`.
 - Encrypted local tokens in `.env.local` require `TOKEN_ENCRYPTION_KEY` to match the key used to encrypt them.
-- Cloud tokens loaded from DynamoDB can also be plaintext or `enc:v1:` encrypted.
-- A decrypt failure means the key is missing, the key does not match, or the encrypted payload is malformed.
+- Cloud tokens loaded from DynamoDB must be `enc:v1:` payloads. Plaintext cloud token rows fail closed at runtime.
+- A decrypt failure means the key is missing, the key does not match, the encrypted payload is malformed, or the cloud token row was stored in plaintext.
 
 Do not print plaintext or encrypted token values in logs, docs, or shell output.
 


### PR DESCRIPTION
## Documentation drift found
- `docs/local-dev-sync-runner.md` still said cloud DynamoDB token rows could be plaintext or `enc:v1:` encrypted.
- Current cloud runtime fails closed unless Google/Notion token rows are already `enc:v1:` encrypted before use.

## Files changed
- `docs/local-dev-sync-runner.md`

## Recent code/workflow changes that caused the drift
- The recent token-handling hardening in `src/gcal/gcal_token.py`, `src/notion/notion_token.py`, and `src/utils/token_crypto.py` now enforces encrypted cloud token reads.
- The same change set also tightened sync-log sanitization and related tests, but this PR only syncs the developer-facing runner documentation.

## Env var changes, if any
- None.

## Backend/Lambda contract changes, if any
- No backend schema change in this PR.
- The documented runtime contract is now explicit that cloud token rows must remain `enc:v1:` encrypted at rest.

## Infra/runtime changes, if any
- None.

## External dependency changes, if any
- None.

## AGENTS.md or skills guidance referenced, if any
- Followed the workspace AGENTS guidance to keep the change minimal and docs-only.

## Validation performed
- `git diff --check`
- Static comparison against current cloud token handling in `src/gcal/gcal_token.py` and `src/notion/notion_token.py`

## Remaining documentation risks
- This PR updates the local dev runner guide only. If future token-contract changes land again, README and deployment docs should be rechecked in the same change set.
