### PR TITLE
CODEX/FIX-ISSUE-102-RETRY-SEMANTICS

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -99,6 +99,8 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 "batchItemFailures": sqs_failures,
                 **_safe_error_payload(context, "google_refresh_error"),
             }
+        if event_type != "eventbridge":
+            return _safe_error_payload(context, "google_refresh_error")
         raise
     except Exception as e:
         logger_obj.exception(f"Unhandled lambda error {e}")
@@ -108,6 +110,8 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 "batchItemFailures": sqs_failures,
                 **_safe_error_payload(context, "lambda_unhandled_error"),
             }
+        if event_type != "eventbridge":
+            return _safe_error_payload(context, "lambda_unhandled_error")
         raise
 
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,24 +1,26 @@
+import json
 import os
 import sys
-import json
 from datetime import datetime, timezone
 from typing import Any, Dict
 
 from google.auth.exceptions import RefreshError
 
-# Ensure the 'src' folder is importable when executed in different CWDs/environments
+# Ensure the 'src' folder is importable when executed in different
+# CWDs/environments.
 _ROOT = os.path.dirname(os.path.abspath(__file__))
 _SRC = os.path.join(_ROOT, "src")
 if _SRC not in sys.path:
     sys.path.append(_SRC)
 
-# Import utility functions and helpers
 from src.utils import get_logger  # noqa: E402
-from src.utils.lambda_utils import detect_event_source, process_sqs_records, process_eventbridge_event  # noqa: E402
+from src.utils.lambda_utils import (  # noqa: E402
+    detect_event_source,
+    process_eventbridge_event,
+    process_sqs_records,
+)
 
-# Set up logger to write to file
 logger_obj = get_logger(__name__)
-
 
 SAFE_SYNC_FAILURE_MESSAGE = "Sync failed. See Lambda logs with aws_request_id for details."
 
@@ -31,7 +33,11 @@ def _all_sqs_batch_failures(event: Dict[str, Any]) -> list[Dict[str, str]]:
     return failures
 
 
-def _safe_error_payload(context: Any, error_code: str, status_code: int = 500) -> Dict[str, Any]:
+def _safe_error_payload(
+    context: Any,
+    error_code: str,
+    status_code: int = 500,
+) -> Dict[str, Any]:
     return {
         "statusCode": status_code,
         "body": {
@@ -45,60 +51,80 @@ def _safe_error_payload(context: Any, error_code: str, status_code: int = 500) -
     }
 
 
-# Main Lambda handler: dispatch to SQS or API event processing
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    """AWS Lambda handler: dispatches to SQS or API helpers and centralises error handling."""
+    """Dispatch Lambda events and preserve trigger-specific failure semantics."""
     lambda_start_time = datetime.now(timezone.utc)
+    event_type = "unknown"
 
     try:
         event_type = detect_event_source(logger_obj, event)
         if event_type == "api":
-            logger_obj.warning("API event processing is not implemented for this Lambda.")
-            return _safe_error_payload(context, "unsupported_event_source", status_code=501)
+            logger_obj.warning(
+                "API event processing is not implemented for this Lambda."
+            )
+            return _safe_error_payload(
+                context,
+                "unsupported_event_source",
+                status_code=501,
+            )
         elif event_type == "sqs":
             from src.main import main as run_sync_notion_and_google  # noqa: E402
 
-            message = process_sqs_records(logger_obj, event, context, run_sync_notion_and_google, lambda_start_time)
-            return message
+            return process_sqs_records(
+                logger_obj,
+                event,
+                context,
+                run_sync_notion_and_google,
+                lambda_start_time,
+            )
         elif event_type == "eventbridge":
             from src.main import main as run_sync_notion_and_google  # noqa: E402
 
-            message = process_eventbridge_event(
-                logger_obj, event, context, run_sync_notion_and_google, lambda_start_time
+            return process_eventbridge_event(
+                logger_obj,
+                event,
+                context,
+                run_sync_notion_and_google,
+                lambda_start_time,
             )
-            return message
-        else:
-            logger_obj.warning(f"Unknown event source: {event_type}")
-            return {"statusCode": 400, "body": {"message": "Unknown event source"}}
+
+        logger_obj.warning(f"Unknown event source: {event_type}")
+        return {"statusCode": 400, "body": {"message": "Unknown event source"}}
 
     except RefreshError as e:
         logger_obj.exception(f"Google token refresh failed {e}")
-        if _all_sqs_batch_failures(event):
+        sqs_failures = _all_sqs_batch_failures(event)
+        if sqs_failures:
             return {
-                "batchItemFailures": _all_sqs_batch_failures(event),
+                "batchItemFailures": sqs_failures,
                 **_safe_error_payload(context, "google_refresh_error"),
             }
-        return _safe_error_payload(context, "google_refresh_error")
+        raise
     except Exception as e:
         logger_obj.exception(f"Unhandled lambda error {e}")
-        if _all_sqs_batch_failures(event):
+        sqs_failures = _all_sqs_batch_failures(event)
+        if sqs_failures:
             return {
-                "batchItemFailures": _all_sqs_batch_failures(event),
+                "batchItemFailures": sqs_failures,
                 **_safe_error_payload(context, "lambda_unhandled_error"),
             }
-        return _safe_error_payload(context, "lambda_unhandled_error")
+        raise
 
 
-# --- Local test entrypoint ---
 if __name__ == "__main__":
-    # import pprint
     UUID = ""
-
-    mock_event = {"Records": [{"body": json.dumps({"uuid": UUID}), "eventSource": "aws:sqs"}]}
-    fake_ctx = type("FakeContext", (), {"function_name": "test-lambda", "aws_request_id": "abc-123"})()
+    mock_event = {
+        "Records": [
+            {"body": json.dumps({"uuid": UUID}), "eventSource": "aws:sqs"}
+        ]
+    }
+    fake_ctx = type(
+        "FakeContext",
+        (),
+        {"function_name": "test-lambda", "aws_request_id": "abc-123"},
+    )()
     response = lambda_handler(mock_event, fake_ctx)
 
-    # pretty print for json response
     from pprint import pprint
 
     pprint(response)

--- a/src/utils/lambda_utils.py
+++ b/src/utils/lambda_utils.py
@@ -22,6 +22,10 @@ class SyncErrorPayload(TypedDict):
     retriable: bool | None
 
 
+class RetryableSyncFailure(RuntimeError):
+    """Raised when a trigger should fail for upstream retry or DLQ handling."""
+
+
 def sanitize_sync_error(error: Any) -> SyncErrorPayload:
     if not isinstance(error, dict):
         return {
@@ -84,6 +88,26 @@ def sanitize_sync_log_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     sanitized_message["omitted_error_count"] = max(original_error_count - MAX_SYNC_LOG_ERRORS, 0)
     sanitized_payload["message"] = sanitized_message
     return sanitized_payload
+
+
+def _iter_sync_errors(payload: Dict[str, Any]) -> list[Dict[str, Any]]:
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        return []
+
+    errors = message.get("errors")
+    if not isinstance(errors, list):
+        return []
+
+    return [error for error in errors if isinstance(error, dict)]
+
+
+def sync_result_requires_retry(payload: Dict[str, Any]) -> bool:
+    status_code = payload.get("statusCode")
+    if isinstance(status_code, int) and status_code >= 500:
+        return True
+
+    return any(error.get("retriable") is True for error in _iter_sync_errors(payload))
 
 
 def _save_sync_logs(uuid: str, payload: Dict[str, Any]) -> None:
@@ -176,7 +200,7 @@ def process_sqs_records(
                 extra={"job_id": job_id},
             )
             sqs_batch_results.append(processed_result)
-            if isinstance(processed_result.get("statusCode"), int) and processed_result.get("statusCode", 500) >= 500:
+            if sync_result_requires_retry(processed_result):
                 batch_item_failures.append({"itemIdentifier": job_id})
         except Exception:
             logger_obj.exception("Error processing SQS record")
@@ -191,9 +215,7 @@ def process_sqs_records(
             batch_item_failures.append({"itemIdentifier": job_id})
 
     # Summarize results for batch logging
-    success_count = sum(
-        1 for s in sqs_batch_results if isinstance(s.get("statusCode"), int) and s.get("statusCode", 500) < 400
-    )
+    success_count = sum(1 for s in sqs_batch_results if not sync_result_requires_retry(s))
     failure_count = len(sqs_batch_results) - success_count
 
     # Emit a final batch summary log
@@ -201,7 +223,7 @@ def process_sqs_records(
     success_uuids = [
         s.get("uuid")
         for s in sqs_batch_results
-        if isinstance(s.get("statusCode"), int) and s.get("statusCode", 500) < 400
+        if not sync_result_requires_retry(s)
     ]
     failure_uuids = [s.get("uuid") for s in sqs_batch_results if s.get("uuid") not in success_uuids]
     batch_sync_result = {
@@ -268,10 +290,14 @@ def process_eventbridge_event(
                 "event_time": event_time,
             },
         )
+        if sync_result_requires_retry(result):
+            raise RetryableSyncFailure(
+                "EventBridge sync produced retriable failure(s)."
+            )
         return result
     except Exception:
         logger_obj.exception("Error processing EventBridge event")
-        return {"statusCode": 500, "body": {"error": "Event processing failed"}}
+        raise
 
 
 def detect_event_source(logger_obj, event: dict) -> str:
@@ -306,4 +332,11 @@ def detect_event_source(logger_obj, event: dict) -> str:
     return "unknown"
 
 
-__all__ = ["process_and_log_sync_result", "process_sqs_records", "detect_event_source"]
+__all__ = [
+    "process_and_log_sync_result",
+    "process_sqs_records",
+    "process_eventbridge_event",
+    "detect_event_source",
+    "sync_result_requires_retry",
+    "RetryableSyncFailure",
+]

--- a/test/test_lambda_handler.py
+++ b/test/test_lambda_handler.py
@@ -26,6 +26,7 @@ sys.modules.setdefault("google.auth.exceptions", google_auth_exceptions_module)
 
 import lambda_function  # noqa: E402
 from google.auth.exceptions import RefreshError  # noqa: E402
+from src.utils.lambda_utils import RetryableSyncFailure  # noqa: E402
 
 
 def _make_context(function_name="test-lambda", aws_request_id="req-123"):
@@ -55,7 +56,10 @@ def _make_sqs_event(*uuids):
 class LambdaHandlerTests(unittest.TestCase):
     def _stub_src_main(self):
         module = types.ModuleType("src.main")
-        module.main = lambda uuid=None: {"statusCode": 200, "body": {"status": "sync_success", "message": uuid}}
+        module.main = lambda uuid=None: {
+            "statusCode": 200,
+            "body": {"status": "sync_success", "message": uuid},
+        }
         return patch.dict(sys.modules, {"src.main": module})
 
     def test_api_event_returns_explicit_501_payload(self):
@@ -67,7 +71,10 @@ class LambdaHandlerTests(unittest.TestCase):
 
         self.assertEqual(result["statusCode"], 501)
         self.assertEqual(result["body"]["status"], "sync_error")
-        self.assertEqual(result["body"]["message"]["error_code"], "unsupported_event_source")
+        self.assertEqual(
+            result["body"]["message"]["error_code"],
+            "unsupported_event_source",
+        )
         self.assertEqual(result["body"]["message"]["aws_request_id"], "req-123")
 
     def test_unhandled_sqs_failure_returns_all_batch_item_failures(self):
@@ -88,7 +95,10 @@ class LambdaHandlerTests(unittest.TestCase):
             result["batchItemFailures"],
             [{"itemIdentifier": "msg-0"}, {"itemIdentifier": "msg-1"}],
         )
-        self.assertEqual(result["body"]["message"]["error_code"], "lambda_unhandled_error")
+        self.assertEqual(
+            result["body"]["message"]["error_code"],
+            "lambda_unhandled_error",
+        )
 
     def test_refresh_error_returns_sqs_batch_item_failures(self):
         event = _make_sqs_event("uuid-1")
@@ -105,7 +115,10 @@ class LambdaHandlerTests(unittest.TestCase):
 
         self.assertEqual(result["statusCode"], 500)
         self.assertEqual(result["batchItemFailures"], [{"itemIdentifier": "msg-0"}])
-        self.assertEqual(result["body"]["message"]["error_code"], "google_refresh_error")
+        self.assertEqual(
+            result["body"]["message"]["error_code"],
+            "google_refresh_error",
+        )
 
     def test_detect_event_source_failure_returns_safe_500_payload(self):
         event = {"detail-type": "scheduled", "source": "aws.events"}
@@ -120,7 +133,49 @@ class LambdaHandlerTests(unittest.TestCase):
 
         self.assertEqual(result["statusCode"], 500)
         self.assertEqual(result["body"]["status"], "sync_error")
-        self.assertEqual(result["body"]["message"]["error_code"], "lambda_unhandled_error")
+        self.assertEqual(
+            result["body"]["message"]["error_code"],
+            "lambda_unhandled_error",
+        )
+
+    def test_eventbridge_retryable_failure_is_re_raised(self):
+        event = {
+            "id": "evt-bridge-1",
+            "detail-type": "sync",
+            "source": "notica.sync",
+            "time": "2026-05-23T00:00:00Z",
+            "detail": {"uuid": "uuid-1"},
+        }
+        context = _make_context(aws_request_id="req-1")
+
+        with patch.object(
+            lambda_function,
+            "detect_event_source",
+            return_value="eventbridge",
+        ):
+            with patch.object(
+                lambda_function,
+                "process_eventbridge_event",
+                side_effect=RetryableSyncFailure("retry this invocation"),
+            ):
+                with self.assertRaises(RetryableSyncFailure):
+                    lambda_function.lambda_handler(event, context)
+
+    def test_sqs_success_result_still_returns_payload(self):
+        event = _make_sqs_event("uuid-1")
+        context = _make_context(aws_request_id="req-1")
+        expected = {"statusCode": 200, "batchItemFailures": []}
+
+        with self._stub_src_main():
+            with patch.object(lambda_function, "detect_event_source", return_value="sqs"):
+                with patch.object(
+                    lambda_function,
+                    "process_sqs_records",
+                    return_value=expected,
+                ):
+                    result = lambda_function.lambda_handler(event, context)
+
+        self.assertEqual(result, expected)
 
 
 if __name__ == "__main__":

--- a/test/test_lambda_handler.py
+++ b/test/test_lambda_handler.py
@@ -153,13 +153,14 @@ class LambdaHandlerTests(unittest.TestCase):
             "detect_event_source",
             return_value="eventbridge",
         ):
-            with patch.object(
-                lambda_function,
-                "process_eventbridge_event",
-                side_effect=RetryableSyncFailure("retry this invocation"),
-            ):
-                with self.assertRaises(RetryableSyncFailure):
-                    lambda_function.lambda_handler(event, context)
+            with self._stub_src_main():
+                with patch.object(
+                    lambda_function,
+                    "process_eventbridge_event",
+                    side_effect=RetryableSyncFailure("retry this invocation"),
+                ):
+                    with self.assertRaises(RetryableSyncFailure):
+                        lambda_function.lambda_handler(event, context)
 
     def test_sqs_success_result_still_returns_payload(self):
         event = _make_sqs_event("uuid-1")

--- a/test/test_lambda_utils.py
+++ b/test/test_lambda_utils.py
@@ -257,6 +257,47 @@ class TestProcessSqsRecords(unittest.TestCase):
         self.assertEqual(result["failure_count"], 1)
         self.assertEqual(result["batchItemFailures"], [{"itemIdentifier": "msg-0"}])
 
+    def test_retriable_sync_error_in_200_result_returns_partial_batch_failure(self):
+        event = _make_sqs_event(["uuid-retry"])
+
+        def run_sync(uuid):  # noqa: ARG001
+            return {
+                "statusCode": 200,
+                "body": {
+                    "status": "sync_success",
+                    "message": {
+                        "summary": {},
+                        "errors": [
+                            {
+                                "action": "update_notion",
+                                "error_code": "provider_write_failed",
+                                "error_message": lambda_utils.SAFE_SYNC_FAILURE_MESSAGE,
+                                "error": None,
+                                "gcal_event_start": "2026-05-23T10:00:00Z",
+                                "gcal_event_id": "evt-123",
+                                "notion_task_id": "page-456",
+                                "retriable": True,
+                            }
+                        ],
+                    },
+                },
+            }
+
+        with patch.object(lambda_utils, "_save_sync_logs"):
+            result = lambda_utils.process_sqs_records(
+                logger_obj=self.logger,
+                event=event,
+                context=self.ctx,
+                run_sync=run_sync,
+                lambda_start_time=self.start,
+            )
+
+        self.assertEqual(result["success_count"], 0)
+        self.assertEqual(result["failure_count"], 1)
+        self.assertEqual(result["success_uuids"], [])
+        self.assertEqual(result["failure_uuids"], ["uuid-retry"])
+        self.assertEqual(result["batchItemFailures"], [{"itemIdentifier": "msg-0"}])
+
     def test_mixed_batch_only_retries_failed_records(self):
         event = _make_sqs_event(["uuid-ok", "uuid-fail", "uuid-ok-2"])
 
@@ -283,6 +324,65 @@ class TestProcessSqsRecords(unittest.TestCase):
         self.assertEqual(result["success_count"], 2)
         self.assertEqual(result["failure_count"], 1)
         self.assertEqual(result["batchItemFailures"], [{"itemIdentifier": "msg-1"}])
+
+
+class TestProcessEventBridgeEvent(unittest.TestCase):
+    def setUp(self):
+        self.ctx = _make_context()
+        self.logger = _make_logger()
+        self.start = datetime.now(timezone.utc)
+        self.event = {
+            "id": "evt-bridge-1",
+            "detail-type": "sync",
+            "source": "notica.sync",
+            "time": "2026-05-23T00:00:00Z",
+            "detail": {"uuid": "uuid-1"},
+        }
+
+    def test_retriable_sync_error_in_200_result_raises_for_retry(self):
+        sync_result = {
+            "statusCode": 200,
+            "body": {
+                "status": "sync_success",
+                "message": {
+                    "summary": {},
+                    "errors": [
+                        {
+                            "action": "update_notion",
+                            "error_code": "provider_write_failed",
+                            "error_message": lambda_utils.SAFE_SYNC_FAILURE_MESSAGE,
+                            "error": None,
+                            "gcal_event_start": "2026-05-23T10:00:00Z",
+                            "gcal_event_id": "evt-123",
+                            "notion_task_id": "page-456",
+                            "retriable": True,
+                        }
+                    ],
+                },
+            },
+        }
+
+        with patch.object(lambda_utils, "_save_sync_logs"):
+            with self.assertRaises(lambda_utils.RetryableSyncFailure):
+                lambda_utils.process_eventbridge_event(
+                    logger_obj=self.logger,
+                    event=self.event,
+                    context=self.ctx,
+                    run_sync=lambda uuid: sync_result,  # noqa: ARG005
+                    lambda_start_time=self.start,
+                )
+
+    def test_non_retriable_result_returns_normally(self):
+        with patch.object(lambda_utils, "_save_sync_logs"):
+            result = lambda_utils.process_eventbridge_event(
+                logger_obj=self.logger,
+                event=self.event,
+                context=self.ctx,
+                run_sync=lambda uuid: _ok_sync_result(),  # noqa: ARG005
+                lambda_start_time=self.start,
+            )
+
+        self.assertEqual(result["statusCode"], 200)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- classify retry-worthy sync results from the sanitized Lambda payload instead of relying on `statusCode` alone
- send SQS records with retriable `message.errors[]` into `batchItemFailures`
- re-raise EventBridge retry-worthy failures through the top-level Lambda handler so upstream retry or DLQ policy can engage
- add focused tests for SQS retry classification, EventBridge failure propagation, and handler re-raise behavior

## Validation
- `uv run python -m unittest discover -s test -p 'test_lambda_utils.py' -v`
- `uv run python -m unittest discover -s test -p 'test_lambda_handler.py' -v`
- `uv run python -m unittest discover -s test -p 'test_sync_sanitization.py' -v`
- `uv run python -m unittest discover -s test -p 'test_sync_log_contract.py' -v`
- `git diff --check`

## Notes
- A repo-wide `flake8` check still reports many existing E501 long-line violations in touched legacy files on `dev`; this PR does not widen that baseline.

Closes #102

Linked Issue: [[P1 Sync] Retriable sync failures are acknowledged instead of retried](https://github.com/HUIXIN-TW/NotionSyncGCal/issues/102)
Fixes #102
