### PR TITLE
CODEX/FIX-ISSUE-98-TOKEN-WRITE-GUARD

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -59,9 +59,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     try:
         event_type = detect_event_source(logger_obj, event)
         if event_type == "api":
-            logger_obj.warning(
-                "API event processing is not implemented for this Lambda."
-            )
+            logger_obj.warning("API event processing is not implemented for this Lambda.")
             return _safe_error_payload(
                 context,
                 "unsupported_event_source",
@@ -117,11 +115,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
 if __name__ == "__main__":
     UUID = ""
-    mock_event = {
-        "Records": [
-            {"body": json.dumps({"uuid": UUID}), "eventSource": "aws:sqs"}
-        ]
-    }
+    mock_event = {"Records": [{"body": json.dumps({"uuid": UUID}), "eventSource": "aws:sqs"}]}
     fake_ctx = type(
         "FakeContext",
         (),

--- a/src/utils/lambda_utils.py
+++ b/src/utils/lambda_utils.py
@@ -220,11 +220,7 @@ def process_sqs_records(
 
     # Emit a final batch summary log
     # Build enhanced batch summary avoiding duplicate 'results' key collisions
-    success_uuids = [
-        s.get("uuid")
-        for s in sqs_batch_results
-        if not sync_result_requires_retry(s)
-    ]
+    success_uuids = [s.get("uuid") for s in sqs_batch_results if not sync_result_requires_retry(s)]
     failure_uuids = [s.get("uuid") for s in sqs_batch_results if s.get("uuid") not in success_uuids]
     batch_sync_result = {
         # Provide an explicit statusCode for downstream handler uniformity
@@ -291,9 +287,7 @@ def process_eventbridge_event(
             },
         )
         if sync_result_requires_retry(result):
-            raise RetryableSyncFailure(
-                "EventBridge sync produced retriable failure(s)."
-            )
+            raise RetryableSyncFailure("EventBridge sync produced retriable failure(s).")
         return result
     except Exception:
         logger_obj.exception("Error processing EventBridge event")


### PR DESCRIPTION
## Summary
- reformat `lambda_function.py` and `src/utils/lambda_utils.py` to satisfy the `black --check` step used by `Deploy Dev Lambda`
- restore the current `dev` branch validation baseline so the workflow can proceed past `Run validation`
- no runtime logic changes beyond formatting

## Root cause
The latest `Deploy Dev Lambda` run on `dev` failed before AWS deploy steps because `uv run black --check src lambda_function.py --line-length 120` reported formatting drift in:
- `lambda_function.py`
- `src/utils/lambda_utils.py`

## Validation
- `uv run black --check src lambda_function.py --line-length 120`
- `uv run flake8 --max-line-length=120 src lambda_function.py test`
- `bash scripts/check_lambda_deploy_workflows.sh`
- `./scripts/check_no_plaintext_secrets.sh`
- `uv run python -m unittest discover -s test -p 'test_lambda_utils.py' -v`
- `uv run python -m unittest discover -s test -p 'test_lambda_handler.py' -v`

## Notes
- Issue #98 was separately verified and closed because the conditional Google token write fix is already present on `dev`.

Linked Issue: [[P2 Data Access] Google OAuth refresh writes can overwrite newer token rows without concurrency checks](https://github.com/HUIXIN-TW/NotionSyncGCal/issues/98)
Fixes #98
