### PR TITLE
CODEX/FIX-GCAL-DELETE-RETRY-LINKAGE

### DIFF
--- a/docs/local-dev-sync-runner.md
+++ b/docs/local-dev-sync-runner.md
@@ -106,12 +106,12 @@ Do not commit `.env.local` or any generated env snippet. Refresh-token generatio
 
 ## Encrypted Tokens
 
-Local and cloud token values may be plaintext or `enc:v1:` encrypted:
+Local tokens may be plaintext or `enc:v1:` encrypted. Cloud DynamoDB token rows must already be `enc:v1:` encrypted:
 
 - Plaintext `NOTION_TOKEN` and `GOOGLE_REFRESH_TOKEN` work without `TOKEN_ENCRYPTION_KEY`.
 - Encrypted local tokens in `.env.local` require `TOKEN_ENCRYPTION_KEY` to match the key used to encrypt them.
-- Cloud tokens loaded from DynamoDB can also be plaintext or `enc:v1:` encrypted.
-- A decrypt failure means the key is missing, the key does not match, or the encrypted payload is malformed.
+- Cloud tokens loaded from DynamoDB must be `enc:v1:` payloads. Plaintext cloud token rows fail closed at runtime.
+- A decrypt failure means the key is missing, the key does not match, the encrypted payload is malformed, or the cloud token row was stored in plaintext.
 
 Do not print plaintext or encrypted token values in logs, docs, or shell output.
 

--- a/src/gcal/gcal_service.py
+++ b/src/gcal/gcal_service.py
@@ -160,8 +160,21 @@ class GoogleService:
         try:
             self.service.events().delete(calendarId=gcal_calendar_id, eventId=gcal_event_id).execute()
             self.logger.info(f"Successfully deleted event with ID: {gcal_event_id}")
+            return True
+        except HttpError as e:
+            status_code = getattr(getattr(e, "resp", None), "status", None)
+            if status_code in (404, 410):
+                self.logger.warning(
+                    "Google Calendar event_id=%s was already absent (status=%s); treating delete as converged.",
+                    gcal_event_id,
+                    status_code,
+                )
+                return True
+            self.logger.error(f"An error occurred while deleting event with ID: {gcal_event_id}: {e}")
+            raise
         except Exception as e:
             self.logger.error(f"An error occurred while deleting event with ID: {gcal_event_id}: {e}")
+            raise
 
     def make_event_body(self, notion_task):
         # set icone and task name

--- a/src/sync/sync.py
+++ b/src/sync/sync.py
@@ -226,6 +226,7 @@ def synchronize_notion_and_google_calendar(
                     action = "delete_gcal"
                     logger.debug("Deleting a Google Calendar event for a Notion task.")
                     google_service.delete_gcal_event(notion_gcal_cal_id, notion_gcal_event_id)
+
                     notion_service.delete_notion_task(notion_task_page_id)
 
                     duplicate_notion_task_list = notion_service.get_notion_task_by_gcal_event_id(notion_gcal_event_id)

--- a/test/test_gcal_recurring.py
+++ b/test/test_gcal_recurring.py
@@ -16,6 +16,7 @@ import sys
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from googleapiclient.errors import HttpError
 
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
 sys.path.insert(0, str(SRC_ROOT))
@@ -569,6 +570,96 @@ class TestGetGcalEventLimit(unittest.TestCase):
         gs = self._make_service_with_items(self._make_n_events(MAX_GCAL_EVENTS_PER_CALENDAR + 1))
         with self.assertRaises(RuntimeError):
             gs.get_gcal_event()
+
+
+class TestDeleteHandling(unittest.TestCase):
+    def _make_delete_task(self):
+        notion_task = _make_notion_task("abc123_20260530T020000Z")
+        notion_task["properties"][MINIMAL_USER_SETTING["page_property"]["Delete_Notion_Name"]] = {"checkbox": True}
+        return notion_task
+
+    def test_delete_failure_preserves_notion_linkage_and_reports_error(self):
+        from sync.sync import synchronize_notion_and_google_calendar
+
+        notion_service = MagicMock()
+        google_service = MagicMock()
+        notion_task = self._make_delete_task()
+
+        notion_service.get_notion_task.return_value = ({}, [notion_task])
+        google_service.get_gcal_event.return_value = []
+        google_service.delete_gcal_event.side_effect = RuntimeError("google delete failed")
+
+        result = synchronize_notion_and_google_calendar(
+            user_setting={**MINIMAL_USER_SETTING},
+            notion_service=notion_service,
+            google_service=google_service,
+            compare_time=True,
+            should_update_notion_tasks=True,
+            should_update_google_events=True,
+        )
+
+        google_service.delete_gcal_event.assert_called_once_with(
+            "cal@group.calendar.google.com",
+            "abc123_20260530T020000Z",
+        )
+        notion_service.delete_notion_task.assert_not_called()
+        notion_service.get_notion_task_by_gcal_event_id.assert_not_called()
+        self.assertEqual(result["statusCode"], 200)
+        self.assertEqual(result["body"]["status"], "sync_success")
+        self.assertEqual(len(result["body"]["message"]["errors"]), 1)
+        error = result["body"]["message"]["errors"][0]
+        self.assertEqual(error["action"], "delete_gcal")
+        self.assertEqual(error["error_code"], "runtime_error")
+        self.assertEqual(
+            error["error_message"],
+            "Sync failed. See Lambda logs with aws_request_id for details.",
+        )
+        self.assertTrue(error["retriable"])
+        self.assertEqual(error["notion_task_id"], notion_task["id"])
+        self.assertEqual(error["gcal_event_id"], "abc123_20260530T020000Z")
+
+
+class TestDeleteGcalEventApiErrors(unittest.TestCase):
+    def _make_service(self):
+        mock_service = MagicMock()
+        logger = MagicMock()
+        with patch("gcal.gcal_service.build", return_value=mock_service):
+            gs = GoogleService(MINIMAL_USER_SETTING, MagicMock(), logger)
+        gs.service = mock_service
+        gs.logger = logger
+        return gs, mock_service, logger
+
+    def test_404_is_treated_as_delete_converged(self):
+        gs, mock_service, logger = self._make_service()
+
+        class _Resp:
+            status = 404
+            reason = "Not Found"
+
+        mock_service.events.return_value.delete.return_value.execute.side_effect = HttpError(
+            _Resp(),
+            b'{"error":{"message":"Not found"}}',
+        )
+
+        result = gs.delete_gcal_event("cal@group.calendar.google.com", "evt-404")
+
+        self.assertTrue(result)
+        logger.warning.assert_called_once()
+
+    def test_non_404_delete_error_is_raised(self):
+        gs, mock_service, logger = self._make_service()
+
+        class _Resp:
+            status = 403
+            reason = "Forbidden"
+
+        http_error = HttpError(_Resp(), b'{"error":{"message":"Forbidden"}}')
+        mock_service.events.return_value.delete.return_value.execute.side_effect = http_error
+
+        with self.assertRaises(HttpError):
+            gs.delete_gcal_event("cal@group.calendar.google.com", "evt-403")
+
+        logger.error.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/test/test_gcal_recurring.py
+++ b/test/test_gcal_recurring.py
@@ -646,18 +646,35 @@ class TestDeleteGcalEventApiErrors(unittest.TestCase):
         self.assertTrue(result)
         logger.warning.assert_called_once()
 
-    def test_non_404_delete_error_is_raised(self):
+    def test_410_is_treated_as_delete_converged(self):
         gs, mock_service, logger = self._make_service()
 
         class _Resp:
-            status = 403
-            reason = "Forbidden"
+            status = 410
+            reason = "Gone"
 
-        http_error = HttpError(_Resp(), b'{"error":{"message":"Forbidden"}}')
+        mock_service.events.return_value.delete.return_value.execute.side_effect = HttpError(
+            _Resp(),
+            b'{"error":{"message":"Gone"}}',
+        )
+
+        result = gs.delete_gcal_event("cal@group.calendar.google.com", "evt-410")
+
+        self.assertTrue(result)
+        logger.warning.assert_called_once()
+
+    def test_500_delete_error_is_raised(self):
+        gs, mock_service, logger = self._make_service()
+
+        class _Resp:
+            status = 500
+            reason = "Internal Server Error"
+
+        http_error = HttpError(_Resp(), b'{"error":{"message":"Internal Server Error"}}')
         mock_service.events.return_value.delete.return_value.execute.side_effect = http_error
 
         with self.assertRaises(HttpError):
-            gs.delete_gcal_event("cal@group.calendar.google.com", "evt-403")
+            gs.delete_gcal_event("cal@group.calendar.google.com", "evt-500")
 
         logger.error.assert_called_once()
 


### PR DESCRIPTION
## What changed
- stop swallowing Google Calendar delete failures for non-404/410 API errors
- treat Google `404`/`410` delete responses as already-converged deletes
- preserve the Notion `GCal_EventId` linkage when Google deletion fails so users can retry a later full sync
- add focused tests for delete failure handling and Google delete API error classification

## Why
A failed Google event deletion was previously logged and ignored, then the sync continued clearing the Notion-side linkage. That made the two systems diverge and removed the identifier needed for a future retry.

Treat Google Calendar 404/410 deletes as converged to make deletion idempotent.

## Impact
- delete failures now remain visible in sync errors
- Notion linkage is preserved for retryable delete failures
- already-missing Google events still allow Notion cleanup to converge

## Validation
- `uv run python -m unittest discover -s test -p 'test_gcal_recurring.py' -v`
- `uv run python -m unittest discover -s test -p 'test_sync_sanitization.py' -v`
- `uv run python -m unittest discover -s test -p 'test_lambda_utils.py' -v`

## Root cause
The Google service layer caught all delete exceptions and only logged them, so the sync orchestration could not distinguish a successful delete from a provider failure.