### PR TITLE
CODEX/FIX-GOOGLE-REFRESH-CONFLICT

### DIFF
--- a/src/gcal/gcal_token.py
+++ b/src/gcal/gcal_token.py
@@ -10,6 +10,7 @@ from utils.token_crypto import (
     decrypt_token,
     decrypt_token_if_encrypted,
 )
+from utils.dynamodb_utils import GoogleTokenWriteConflictError
 
 _DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token"
 _DEFAULT_SCOPES = [
@@ -145,6 +146,15 @@ class GoogleToken:
             self._save_credentials(credentials)
             self.logger.info("Successfully refreshed tokens.")
             return credentials
+        except GoogleTokenWriteConflictError:
+            if self.mode == "cloud":
+                self.logger.warning(
+                    "Google credentials were refreshed by another worker first; reloading the latest token row."
+                )
+                latest_credentials = self._load_credentials()
+                self.credentials = latest_credentials
+                return latest_credentials
+            raise
         except Exception as e:
             if self.mode == "local":
                 raise RefreshError(
@@ -172,6 +182,8 @@ class GoogleToken:
                 self.logger.info("Saved credentials to DynamoDB.")
             elif self.mode == "local":
                 self.logger.debug("Local mode: skipping credential persistence.")
+        except GoogleTokenWriteConflictError:
+            raise
         except Exception as e:
             self.logger.error(f"Error saving credentials: {e}")
             raise SettingError(f"Error saving credentials: {e}")

--- a/src/gcal/gcal_token.py
+++ b/src/gcal/gcal_token.py
@@ -48,7 +48,7 @@ class GoogleToken:
             credentials = self._refresh_tokens(credentials)
         self.credentials = credentials
 
-    def _load_credentials(self):
+    def _load_credentials(self, consistent_read: bool = False):
         if not self.config:
             raise SettingError("Configuration is required to load settings.")
         if self.mode == "cloud":
@@ -56,7 +56,7 @@ class GoogleToken:
                 from utils.dynamodb_utils import get_google_token_by_uuid
 
                 self.logger.debug("Loading credentials from DynamoDB")
-                data = get_google_token_by_uuid(self.config.get("uuid"))
+                data = get_google_token_by_uuid(self.config.get("uuid"), consistent_read=consistent_read)
                 self._loaded_updated_at = data.get("updatedAt")
                 try:
                     access_token = decrypt_token(data.get("accessToken"))
@@ -151,7 +151,7 @@ class GoogleToken:
                 self.logger.warning(
                     "Google credentials were refreshed by another worker first; reloading the latest token row."
                 )
-                latest_credentials = self._load_credentials()
+                latest_credentials = self._load_credentials(consistent_read=True)
                 self.credentials = latest_credentials
                 return latest_credentials
             raise

--- a/src/utils/dynamodb_utils.py
+++ b/src/utils/dynamodb_utils.py
@@ -5,6 +5,10 @@ import boto3
 from utils.token_crypto import encrypt_token_if_plaintext
 
 
+class GoogleTokenWriteConflictError(RuntimeError):
+    """Raised when a Google token update loses a conditional-write race."""
+
+
 def _get_dynamodb():
     return boto3.resource("dynamodb", region_name=os.getenv("APP_REGION"))
 
@@ -125,17 +129,25 @@ def update_google_token_by_uuid(
     else:
         condition_expression = "attribute_not_exists(updatedAt) OR updatedAt = :expected_updated"
         expression_attribute_values[":expected_updated"] = expected_updated_at
-    google_tbl.update_item(
-        Key={"uuid": uuid},
-        UpdateExpression="""
-            SET accessToken = :at,
-                refreshToken = :rt,
-                expiryDate = :expiry,
-                updatedAt = :updated
-        """,
-        ConditionExpression=condition_expression,
-        ExpressionAttributeValues=expression_attribute_values,
-    )
+    try:
+        google_tbl.update_item(
+            Key={"uuid": uuid},
+            UpdateExpression="""
+                SET accessToken = :at,
+                    refreshToken = :rt,
+                    expiryDate = :expiry,
+                    updatedAt = :updated
+            """,
+            ConditionExpression=condition_expression,
+            ExpressionAttributeValues=expression_attribute_values,
+        )
+    except Exception as exc:
+        error_code = getattr(exc, "response", {}).get("Error", {}).get("Code")
+        if error_code == "ConditionalCheckFailedException":
+            raise GoogleTokenWriteConflictError(
+                f"Google token row for uuid '{uuid}' was updated by another writer."
+            ) from exc
+        raise
 
 
 # get notion config in user table by uuid
@@ -164,6 +176,7 @@ __all__ = [
     "save_sync_logs",
     "get_notion_token_by_uuid",
     "get_google_token_by_uuid",
+    "GoogleTokenWriteConflictError",
     "update_google_token_by_uuid",
     "get_notion_config_by_uuid",
     "update_notion_config_by_uuid",

--- a/src/utils/dynamodb_utils.py
+++ b/src/utils/dynamodb_utils.py
@@ -97,9 +97,9 @@ def get_notion_token_by_uuid(uuid: str) -> str:
 
 
 # get data from google oauth token tables by uuid
-def get_google_token_by_uuid(uuid: str) -> str:
+def get_google_token_by_uuid(uuid: str, consistent_read: bool = False) -> str:
     google_tbl = _get_google_tables()
-    response = google_tbl.get_item(Key={"uuid": uuid})
+    response = google_tbl.get_item(Key={"uuid": uuid}, ConsistentRead=consistent_read)
     item = response.get("Item")
     if not item:
         raise ValueError(f"No Google token found for uuid: {uuid}")

--- a/test/test_dynamodb_utils.py
+++ b/test/test_dynamodb_utils.py
@@ -33,6 +33,7 @@ class DynamoDbGoogleTokenTests(unittest.TestCase):
             item = get_google_token_by_uuid("u-1")
         self.assertEqual(item["accessToken"], "enc:v1:encrypted-access")
         self.assertEqual(item["refreshToken"], "enc:v1:encrypted-refresh")
+        table.get_item.assert_called_once_with(Key={"uuid": "u-1"}, ConsistentRead=False)
 
     def test_get_google_token_returns_plaintext_fields_unchanged(self):
         table = MagicMock()
@@ -47,6 +48,21 @@ class DynamoDbGoogleTokenTests(unittest.TestCase):
             item = get_google_token_by_uuid("u-1")
         self.assertEqual(item["accessToken"], "plain-access")
         self.assertEqual(item["refreshToken"], "plain-refresh")
+
+    def test_get_google_token_supports_consistent_read(self):
+        table = MagicMock()
+        table.get_item.return_value = {
+            "Item": {
+                "uuid": "u-1",
+                "accessToken": "plain-access",
+                "refreshToken": "plain-refresh",
+            }
+        }
+        with patch("utils.dynamodb_utils._get_google_tables", return_value=table):
+            item = get_google_token_by_uuid("u-1", consistent_read=True)
+        self.assertEqual(item["accessToken"], "plain-access")
+        self.assertEqual(item["refreshToken"], "plain-refresh")
+        table.get_item.assert_called_once_with(Key={"uuid": "u-1"}, ConsistentRead=True)
 
     def test_update_google_token_encrypts_plaintext_fields(self):
         table = MagicMock()

--- a/test/test_dynamodb_utils.py
+++ b/test/test_dynamodb_utils.py
@@ -12,6 +12,7 @@ boto3_module.resource = MagicMock()
 sys.modules.setdefault("boto3", boto3_module)
 
 from utils.dynamodb_utils import (  # noqa: E402
+    GoogleTokenWriteConflictError,
     get_google_token_by_uuid,
     update_google_token_by_uuid,
 )
@@ -113,6 +114,23 @@ class DynamoDbGoogleTokenTests(unittest.TestCase):
         kwargs = table.update_item.call_args.kwargs
         self.assertEqual(kwargs["ConditionExpression"], "attribute_not_exists(updatedAt)")
         self.assertNotIn(":expected_updated", kwargs["ExpressionAttributeValues"])
+
+    def test_update_google_token_maps_conditional_conflict(self):
+        table = MagicMock()
+
+        class _ConditionalFailure(Exception):
+            def __init__(self):
+                self.response = {"Error": {"Code": "ConditionalCheckFailedException"}}
+
+        table.update_item.side_effect = _ConditionalFailure()
+
+        with patch("utils.dynamodb_utils._get_google_tables", return_value=table):
+            with patch(
+                "utils.dynamodb_utils.encrypt_token_if_plaintext",
+                side_effect=["enc:v1:access", "enc:v1:refresh"],
+            ):
+                with self.assertRaises(GoogleTokenWriteConflictError):
+                    update_google_token_by_uuid("u-1", "plain-access", "plain-refresh", "111", "222", "123")
 
 
 if __name__ == "__main__":

--- a/test/test_gcal_token.py
+++ b/test/test_gcal_token.py
@@ -340,7 +340,7 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
                 ) as mock_ssm:
                     with patch.dict(os.environ, _CLOUD_ENV):
                         gt = GoogleToken(self._cloud_config("my-uuid"), _make_logger())
-                    mock_loader.assert_called_once_with("my-uuid")
+                    mock_loader.assert_called_once_with("my-uuid", consistent_read=False)
                     mock_ssm.assert_called_once_with(
                         "/dev/notica/google_calendar_client_secret"
                     )
@@ -853,6 +853,61 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
                     with self.assertRaises(SettingError) as ctx:
                         GoogleToken(self._cloud_config(), _make_logger())
                     self.assertIn("DDB down", str(ctx.exception))
+
+    def test_cloud_refresh_conflict_reloads_latest_token_row_with_consistent_read(self):
+        expired_response = {
+            "accessToken": "enc:v1:expired-access-token",
+            "refreshToken": "enc:v1:expired-refresh-token",
+            "expiryDate": str(
+                int(datetime(2000, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+            ),
+            "updatedAt": _CLOUD_DYNAMO_RESPONSE["updatedAt"],
+        }
+        refreshed_response = {
+            "accessToken": "enc:v1:latest-access-token",
+            "refreshToken": "enc:v1:latest-refresh-token",
+            "expiryDate": _FUTURE_EXPIRY_MS,
+            "updatedAt": "1710000009999",
+        }
+
+        def refresh_credentials(credentials, request):  # noqa: ARG001
+            credentials.token = "refreshed-access-token"
+            credentials._refresh_token = "refreshed-refresh-token"
+            credentials.expiry = datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+        with patch.dict(os.environ, _CLOUD_ENV, clear=True):
+            with patch(
+                "utils.dynamodb_utils.get_google_token_by_uuid",
+                side_effect=[expired_response, refreshed_response],
+            ) as mock_loader:
+                with patch(
+                    "utils.dynamodb_utils.update_google_token_by_uuid",
+                    side_effect=GoogleTokenWriteConflictError("row updated"),
+                ):
+                    with patch(
+                        "google.oauth2.credentials.Credentials.refresh",
+                        new=refresh_credentials,
+                    ):
+                        with patch(
+                            "gcal.gcal_token.decrypt_token",
+                            side_effect=[
+                                "old-access-token",
+                                "old-refresh-token",
+                                "latest-access-token",
+                                "latest-refresh-token",
+                            ],
+                        ):
+                            with patch(
+                                "gcal.gcal_token.get_ssm_parameter",
+                                return_value="gcal-client-secret",
+                            ):
+                                gt = GoogleToken(self._cloud_config(), _make_logger())
+
+        self.assertEqual(gt.credentials.token, "latest-access-token")
+        self.assertEqual(gt.credentials.refresh_token, "latest-refresh-token")
+        self.assertEqual(gt._loaded_updated_at, refreshed_response["updatedAt"])
+        self.assertEqual(mock_loader.call_args_list[0].kwargs["consistent_read"], False)
+        self.assertEqual(mock_loader.call_args_list[1].kwargs["consistent_read"], True)
 
 
 class TestGoogleTokenUnknownMode(unittest.TestCase):

--- a/test/test_gcal_token.py
+++ b/test/test_gcal_token.py
@@ -96,6 +96,7 @@ from gcal.gcal_token import (  # noqa: E402
     _DEFAULT_TOKEN_URI,
 )
 from google.oauth2.credentials import Credentials  # noqa: E402
+from utils.dynamodb_utils import GoogleTokenWriteConflictError  # noqa: E402
 from utils.token_crypto import TokenCryptoError  # noqa: E402
 import utils.dynamodb_utils  # noqa: E402,F401
 
@@ -786,6 +787,59 @@ class TestGoogleTokenCloudMode(unittest.TestCase):
             gt._loaded_updated_at,
             str(int(datetime(2026, 1, 2, tzinfo=timezone.utc).timestamp() * 1000)),
         )
+
+    def test_cloud_refresh_conflict_reloads_latest_token_row(self):
+        expired_response = {
+            "accessToken": "enc:v1:expired-access-token",
+            "refreshToken": "enc:v1:expired-refresh-token",
+            "expiryDate": str(
+                int(datetime(2000, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+            ),
+            "updatedAt": _CLOUD_DYNAMO_RESPONSE["updatedAt"],
+        }
+        refreshed_response = {
+            "accessToken": "enc:v1:latest-access-token",
+            "refreshToken": "enc:v1:latest-refresh-token",
+            "expiryDate": _FUTURE_EXPIRY_MS,
+            "updatedAt": "1710000009999",
+        }
+
+        def refresh_credentials(credentials, request):  # noqa: ARG001
+            credentials.token = "refreshed-access-token"
+            credentials._refresh_token = "refreshed-refresh-token"
+            credentials.expiry = datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+        with patch.dict(os.environ, _CLOUD_ENV, clear=True):
+            with patch(
+                "utils.dynamodb_utils.get_google_token_by_uuid",
+                side_effect=[expired_response, refreshed_response],
+            ):
+                with patch(
+                    "utils.dynamodb_utils.update_google_token_by_uuid",
+                    side_effect=GoogleTokenWriteConflictError("row updated"),
+                ):
+                    with patch(
+                        "google.oauth2.credentials.Credentials.refresh",
+                        new=refresh_credentials,
+                    ):
+                        with patch(
+                            "gcal.gcal_token.decrypt_token",
+                            side_effect=[
+                                "old-access-token",
+                                "old-refresh-token",
+                                "latest-access-token",
+                                "latest-refresh-token",
+                            ],
+                        ):
+                            with patch(
+                                "gcal.gcal_token.get_ssm_parameter",
+                                return_value="gcal-client-secret",
+                            ):
+                                gt = GoogleToken(self._cloud_config(), _make_logger())
+
+        self.assertEqual(gt.credentials.token, "latest-access-token")
+        self.assertEqual(gt.credentials.refresh_token, "latest-refresh-token")
+        self.assertEqual(gt._loaded_updated_at, refreshed_response["updatedAt"])
 
     def test_cloud_dynamodb_error_raises_setting_error(self):
         with patch(


### PR DESCRIPTION
## What changed
- map DynamoDB conditional-write races during Google token persistence into an explicit write-conflict exception
- treat cloud refresh write conflicts as a safe concurrency outcome by reloading the latest token row instead of surfacing an auth failure
- add focused tests for conditional conflict mapping and refresh conflict reload behavior

## Why
Two workers can refresh the same Google OAuth token row concurrently. After the stale-overwrite guard was added, the loser of that race started surfacing a generic `RefreshError`, which incorrectly implied the refresh token was invalid or expired.

## Impact
- benign token refresh races no longer look like user reauthorization failures
- cloud refresh flow reuses the freshest persisted credentials when another worker wins the write race
- malformed/encryption/runtime failures still fail closed as before

## Validation
- `uv run python -m unittest discover -s test -p 'test_gcal_token.py' -v`
- `uv run python -m unittest discover -s test -p 'test_dynamodb_utils.py' -v`

## Root cause
The refresh persistence path treated DynamoDB conditional-write conflicts like any other refresh failure, so a concurrency guardrail was being reported as an OAuth auth problem.

Closes #107.